### PR TITLE
Save flight points

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,31 +24,16 @@ jobs:
         os: [ windows-latest, ubuntu-latest ]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
 
       - name: Install Poetry
         run: pipx install poetry==1.1.15
-        shell: bash
 
-      - name: Poetry path
-        run: echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - uses: actions/cache@v2
-        if: ${{ startsWith(runner.os, 'Linux') }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-${{ hashFiles('**/poetry.lock') }}
-
-      - uses: actions/cache@v2
-        if: ${{ startsWith(runner.os, 'macOS') }}
-        with:
-          path: ~/Library/Caches/pypoetry
-          key: ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-${{ hashFiles('**/poetry.lock') }}
+          python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Activate environment and install dependencies
         run: poetry install
@@ -73,7 +58,7 @@ jobs:
           project-token: ${{ secrets.codacy }}
           coverage-reports: coverage.xml
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: ${{ runner.os == 'Windows' && matrix.python-version == '3.8' }} # Using Windows for covering XFOIL calls
         with:
           #          flags: unittests  # optional

--- a/src/fastga/models/performances/mission/dynamic_equilibrium.py
+++ b/src/fastga/models/performances/mission/dynamic_equilibrium.py
@@ -22,7 +22,7 @@ import openmdao.api as om
 from scipy.constants import g
 from scipy.optimize import fsolve
 import pandas as pd
-from fastoad.model_base import FlightPoint
+import fastoad.api as oad
 from copy import deepcopy
 
 from stdatm import Atmosphere

--- a/src/fastga/models/performances/mission/dynamic_equilibrium.py
+++ b/src/fastga/models/performances/mission/dynamic_equilibrium.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 
 from stdatm import Atmosphere
 
-# Definition of Fast-ga custom flight point parameters
+# Definition of Fast-ga custom fields
 FAST_GA_fields = {
     "gamma": {"name": "gamma", "unit": "rad"},
     "alpha": {"name": "alpha", "unit": "deg"},
@@ -35,7 +35,7 @@ FAST_GA_fields = {
     "cl_htp": {"name": "cl_htp", "unit": ""},
 }
 
-# Extending FlightPoint dataclass
+# Extending FlightPoint dataclass, see FAST-OAD FlightPoint documentation
 col_name = oad.FlightPoint.__annotations__
 for key in FAST_GA_fields.keys():
     if FAST_GA_fields[key]["name"] not in col_name:
@@ -403,7 +403,7 @@ class DynamicEquilibrium(om.ExplicitComponent):
 
         return np.array([f1, f2])
 
-    def add_flight_point(self, flight_point: FlightPoint = None, equilibrium_result: tuple = None):
+    def add_flight_point(self, flight_point: oad.FlightPoint = None, equilibrium_result: tuple = None):
 
         """
         Method to add single flight_point to a list of flight_point and treats equilibirum_result at the same time
@@ -421,7 +421,7 @@ class DynamicEquilibrium(om.ExplicitComponent):
             self.flight_points.append(deepcopy(flight_point))
 
     def complete_flight_point(
-        self, flight_point: FlightPoint, mach=None, v_cas=None, v_tas=None, climb_rate=0.0
+        self, flight_point: oad.FlightPoint, mach=None, v_cas=None, v_tas=None, climb_rate=0.0
     ):
 
         """

--- a/src/fastga/models/performances/mission/dynamic_equilibrium.py
+++ b/src/fastga/models/performances/mission/dynamic_equilibrium.py
@@ -29,20 +29,19 @@ from stdatm import Atmosphere
 
 # Definition of Fast-ga custom flight point parameters
 FAST_GA_fields = {
-    'gamma': {'name':'gamma','unit':'rad'},
-    "alpha": {'name':'alpha','unit':'deg'},
-    "cl_wing": {'name':'cl_wing','unit':''},
-    "cl_htp": {'name':'cl_htp','unit':''},
+    "gamma": {"name": "gamma", "unit": "rad"},
+    "alpha": {"name": "alpha", "unit": "deg"},
+    "cl_wing": {"name": "cl_wing", "unit": ""},
+    "cl_htp": {"name": "cl_htp", "unit": ""},
 }
 
 # Extending FlightPoint dataclass
 col_name = FlightPoint.__annotations__
 for key in FAST_GA_fields.keys():
-    if FAST_GA_fields[key]['name'] not in col_name:
-        FlightPoint.add_field(name=FAST_GA_fields[key]['name'], unit=FAST_GA_fields[key]['unit'])
+    if FAST_GA_fields[key]["name"] not in col_name:
+        FlightPoint.add_field(name=FAST_GA_fields[key]["name"], unit=FAST_GA_fields[key]["unit"])
 
 _LOGGER = logging.getLogger(__name__)
-
 
 
 class DynamicEquilibrium(om.ExplicitComponent):
@@ -421,7 +420,9 @@ class DynamicEquilibrium(om.ExplicitComponent):
 
             self.flight_points.append(deepcopy(flight_point))
 
-    def complete_flight_point(self, flight_point: FlightPoint, mach=None, v_cas=None, v_tas=None, climb_rate=0.0):
+    def complete_flight_point(
+        self, flight_point: FlightPoint, mach=None, v_cas=None, v_tas=None, climb_rate=0.0
+    ):
 
         """
         Method to complete velocity fields in flight_point. Uses ONE of [v_cas, v_tas, mach] velocity to set the others.
@@ -448,11 +449,10 @@ class DynamicEquilibrium(om.ExplicitComponent):
             atm.mach = mach
 
         else:
-            raise ValueError('Either v_cas or v_tas must be given to complete flight_point')
+            raise ValueError("Either v_cas or v_tas must be given to complete flight_point")
 
         flight_point.mach = atm.mach
         flight_point.true_airspeed = atm.true_airspeed
         flight_point.equivalent_airspeed = atm.equivalent_airspeed
         flight_point.calibrated_airspeed = atm.calibrated_airspeed
         flight_point.gamma = np.arcsin(climb_rate / atm.true_airspeed)
-

--- a/src/fastga/models/performances/mission/dynamic_equilibrium.py
+++ b/src/fastga/models/performances/mission/dynamic_equilibrium.py
@@ -39,7 +39,9 @@ FAST_GA_fields = {
 col_name = oad.FlightPoint.__annotations__
 for key in FAST_GA_fields.keys():
     if FAST_GA_fields[key]["name"] not in col_name:
-        oad.FlightPoint.add_field(name=FAST_GA_fields[key]["name"], unit=FAST_GA_fields[key]["unit"])
+        oad.FlightPoint.add_field(
+            name=FAST_GA_fields[key]["name"], unit=FAST_GA_fields[key]["unit"]
+        )
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -403,7 +405,9 @@ class DynamicEquilibrium(om.ExplicitComponent):
 
         return np.array([f1, f2])
 
-    def add_flight_point(self, flight_point: oad.FlightPoint = None, equilibrium_result: tuple = None):
+    def add_flight_point(
+        self, flight_point: oad.FlightPoint = None, equilibrium_result: tuple = None
+    ):
 
         """
         Method to add single flight_point to a list of flight_point and treats equilibirum_result at the same time
@@ -449,7 +453,9 @@ class DynamicEquilibrium(om.ExplicitComponent):
             atm.mach = mach
 
         else:
-            raise ValueError("Either v_cas, v_tas or mach number must be given to complete flight_point")
+            raise ValueError(
+                "Either v_cas, v_tas or mach number must be given to complete flight_point"
+            )
 
         flight_point.mach = atm.mach
         flight_point.true_airspeed = atm.true_airspeed

--- a/src/fastga/models/performances/mission/dynamic_equilibrium.py
+++ b/src/fastga/models/performances/mission/dynamic_equilibrium.py
@@ -31,8 +31,13 @@ from stdatm import Atmosphere
 FAST_GA_fields = {
     "gamma": {"name": "gamma", "unit": "rad"},
     "alpha": {"name": "alpha", "unit": "deg"},
-    "cl_wing": {"name": "cl_wing", "unit": ""},
-    "cl_htp": {"name": "cl_htp", "unit": ""},
+    "CL_wing": {"name": "CL_wing", "unit": "-"},
+    "CL_htp": {"name": "CL_htp", "unit": "-"},
+}
+
+FAST_FIELDS_TO_REMOVE = {
+    "slope_angle": {"name": "slope_angle"},
+    "acceleration": {"name": "acceleration"},
 }
 
 # Extending FlightPoint dataclass, see FAST-OAD FlightPoint documentation
@@ -41,6 +46,11 @@ for key in FAST_GA_fields.keys():
     if FAST_GA_fields[key]["name"] not in col_name:
         oad.FlightPoint.add_field(
             name=FAST_GA_fields[key]["name"], unit=FAST_GA_fields[key]["unit"]
+        )
+for key in FAST_FIELDS_TO_REMOVE.keys():
+    if FAST_FIELDS_TO_REMOVE[key]["name"] in col_name:
+        oad.FlightPoint.remove_field(
+            name=FAST_FIELDS_TO_REMOVE[key]["name"]
         )
 
 _LOGGER = logging.getLogger(__name__)
@@ -419,8 +429,9 @@ class DynamicEquilibrium(om.ExplicitComponent):
         if flight_point is not None:
             if equilibrium_result is not None:
                 flight_point.alpha = float(equilibrium_result[0]) * 180.0 / np.pi
-                flight_point.cl_wing = float(equilibrium_result[2])
-                flight_point.cl_htp = float(equilibrium_result[3])
+                flight_point.CL_wing = float(equilibrium_result[2])
+                flight_point.CL_htp = float(equilibrium_result[3])
+                flight_point.CL = float(equilibrium_result[2]+equilibrium_result[3])
 
             self.flight_points.append(deepcopy(flight_point))
 

--- a/src/fastga/models/performances/mission/dynamic_equilibrium.py
+++ b/src/fastga/models/performances/mission/dynamic_equilibrium.py
@@ -36,10 +36,10 @@ FAST_GA_fields = {
 }
 
 # Extending FlightPoint dataclass
-col_name = FlightPoint.__annotations__
+col_name = oad.FlightPoint.__annotations__
 for key in FAST_GA_fields.keys():
     if FAST_GA_fields[key]["name"] not in col_name:
-        FlightPoint.add_field(name=FAST_GA_fields[key]["name"], unit=FAST_GA_fields[key]["unit"])
+        oad.FlightPoint.add_field(name=FAST_GA_fields[key]["name"], unit=FAST_GA_fields[key]["unit"])
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -284,7 +284,7 @@ class DynamicEquilibrium(om.ExplicitComponent):
         dataframe_to_add = dataframe_to_add.applymap(as_scalar)
         rename_dict = {
             field_name: f"{field_name} [{unit}]"
-            for field_name, unit in FlightPoint.get_units().items()
+            for field_name, unit in oad.FlightPoint.get_units().items()
         }
         dataframe_to_add.rename(columns=rename_dict, inplace=True)
 
@@ -414,7 +414,7 @@ class DynamicEquilibrium(om.ExplicitComponent):
 
         if flight_point is not None:
             if equilibrium_result is not None:
-                flight_point.alpha = float(equilibrium_result[0]) * 180.0 / math.pi
+                flight_point.alpha = float(equilibrium_result[0]) * 180.0 / np.pi
                 flight_point.cl_wing = float(equilibrium_result[2])
                 flight_point.cl_htp = float(equilibrium_result[3])
 
@@ -449,7 +449,7 @@ class DynamicEquilibrium(om.ExplicitComponent):
             atm.mach = mach
 
         else:
-            raise ValueError("Either v_cas or v_tas must be given to complete flight_point")
+            raise ValueError("Either v_cas, v_tas or mach number must be given to complete flight_point")
 
         flight_point.mach = atm.mach
         flight_point.true_airspeed = atm.true_airspeed

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -130,13 +130,15 @@ class ComputeClimb(DynamicEquilibrium):
 
         while altitude_t < cruise_altitude:
 
-            flight_point = oad.FlightPoint(altitude=altitude_t,
-                                           time=time_t,
-                                           ground_distance=distance_t,
-                                           engine_setting=EngineSetting.CLIMB,
-                                           thrust_is_regulated=True,
-                                           mass=mass_t,
-                                           name='sizing:main_route:climb')
+            flight_point = oad.FlightPoint(
+                altitude=altitude_t,
+                time=time_t,
+                ground_distance=distance_t,
+                engine_setting=EngineSetting.CLIMB,
+                thrust_is_regulated=True,
+                mass=mass_t,
+                name="sizing:main_route:climb",
+            )
 
             climb_rate = interp1d([0.0, float(cruise_altitude)], [climb_rate_sl, climb_rate_cl])(
                 altitude_t
@@ -156,7 +158,14 @@ class ComputeClimb(DynamicEquilibrium):
 
             # Find equilibrium
             previous_step = self.dynamic_equilibrium(
-                inputs, flight_point.gamma, dynamic_pressure, dvx_dt, 0.0, mass_t, "none", previous_step[0:2]
+                inputs,
+                flight_point.gamma,
+                dynamic_pressure,
+                dvx_dt,
+                0.0,
+                mass_t,
+                "none",
+                previous_step[0:2],
             )
             flight_point.thrust = float(previous_step[1])
 
@@ -190,7 +199,7 @@ class ComputeClimb(DynamicEquilibrium):
                 )
 
         # Save mission
-        if self.options['out_file'] != '':
+        if self.options["out_file"] != "":
             self.save_csv()
 
         outputs["data:mission:sizing:main_route:climb:fuel"] = mass_fuel_t

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -30,7 +30,7 @@ from stdatm import Atmosphere
 
 from fastga.models.performances.mission.takeoff import SAFETY_HEIGHT
 
-from ..dynamic_equilibrium import DynamicEquilibrium, save_df
+from ..dynamic_equilibrium import DynamicEquilibrium
 from ..constants import SUBMODEL_CLIMB, SUBMODEL_CLIMB_SPEED
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,8 +124,6 @@ class ComputeClimb(DynamicEquilibrium):
         # Calculate constant speed (cos(gamma)~1) and corresponding climb angle
         atm = Atmosphere(altitude_t, altitude_in_feet=False)
         atm.calibrated_airspeed = v_cas
-        v_tas = atm.true_airspeed
-        gamma = np.arcsin(climb_rate_sl / v_tas)
 
         # Define specific time step ~POINTS_NB_CLIMB points for calculation (with ground conditions)
         time_step = ((cruise_altitude - SAFETY_HEIGHT) / climb_rate_sl) / float(POINTS_NB_CLIMB)
@@ -150,7 +148,6 @@ class ComputeClimb(DynamicEquilibrium):
             atm.calibrated_airspeed = v_cas
             v_tas = atm.true_airspeed
 
-            gamma = np.arcsin(climb_rate / v_tas)
             atm_1 = Atmosphere(altitude_t + 1.0, altitude_in_feet=False)
             atm_1.calibrated_airspeed = v_cas
             dv_tas_dh = atm_1.true_airspeed - v_tas
@@ -174,8 +171,8 @@ class ComputeClimb(DynamicEquilibrium):
             consumed_mass_1s = propulsion_model.get_consumed_mass(flight_point, 1.0)
 
             # Calculate distance variation (earth axis)
-            v_z = v_tas * np.sin(gamma)
-            v_x = v_tas * np.cos(gamma)
+            v_z = v_tas * np.sin(flight_point.gamma)
+            v_x = v_tas * np.cos(flight_point.gamma)
             time_step = min(time_step, (cruise_altitude - altitude_t) / v_z)
             altitude_t += v_z * time_step
             distance_t += v_x * time_step

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -119,6 +119,7 @@ class ComputeClimb(DynamicEquilibrium):
         mass_t = mtow - (m_to + m_tk + m_ic)
         mass_fuel_t = 0.0
         previous_step = ()
+        self.flight_points = []
 
         # Calculate constant speed (cos(gamma)~1) and corresponding climb angle
         atm = Atmosphere(altitude_t, altitude_in_feet=False)
@@ -132,7 +133,7 @@ class ComputeClimb(DynamicEquilibrium):
         while altitude_t < cruise_altitude:
 
             flight_point = oad.FlightPoint(altitude=altitude_t,
-                                           time= time_t,
+                                           time=time_t,
                                            ground_distance=distance_t,
                                            engine_setting=EngineSetting.CLIMB,
                                            thrust_is_regulated=True,
@@ -167,7 +168,8 @@ class ComputeClimb(DynamicEquilibrium):
             if flight_point.thrust_rate > 1.0:
                 _LOGGER.warning("Thrust rate is above 1.0, value clipped at 1.0")
 
-            self.add_flight_point(flight_point= flight_point, equilibrium_result=previous_step)
+            # Save results
+            self.add_flight_point(flight_point=flight_point, equilibrium_result=previous_step)
 
             consumed_mass_1s = propulsion_model.get_consumed_mass(flight_point, 1.0)
 

--- a/src/fastga/models/performances/mission/mission_components/cruise.py
+++ b/src/fastga/models/performances/mission/mission_components/cruise.py
@@ -23,7 +23,7 @@ from fastoad.constants import EngineSetting
 
 from stdatm import Atmosphere
 
-from ..dynamic_equilibrium import DynamicEquilibrium, save_df
+from ..dynamic_equilibrium import DynamicEquilibrium
 from ..constants import SUBMODEL_CRUISE
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class ComputeCruise(DynamicEquilibrium):
         mass_t = mtow - (m_to + m_tk + m_ic + m_cl)
         atm = Atmosphere(cruise_altitude, altitude_in_feet=False)
         atm.true_airspeed = v_tas
-        mach = atm.mach
+
         previous_step = ()
         self.flight_points = []
 

--- a/src/fastga/models/performances/mission/mission_components/cruise.py
+++ b/src/fastga/models/performances/mission/mission_components/cruise.py
@@ -121,13 +121,15 @@ class ComputeCruise(DynamicEquilibrium):
 
         while distance_t < cruise_distance:
 
-            flight_point = oad.FlightPoint(altitude=cruise_altitude,
-                                           time=time_t,
-                                           ground_distance=distance_t,
-                                           engine_setting=EngineSetting.CRUISE,
-                                           thrust_is_regulated=True,
-                                           mass=mass_t,
-                                           name='sizing:main_route:cruise')
+            flight_point = oad.FlightPoint(
+                altitude=cruise_altitude,
+                time=time_t,
+                ground_distance=distance_t,
+                engine_setting=EngineSetting.CRUISE,
+                thrust_is_regulated=True,
+                mass=mass_t,
+                name="sizing:main_route:cruise",
+            )
             self.complete_flight_point(flight_point, v_tas=v_tas)
 
             # Calculate dynamic pressure

--- a/src/fastga/models/performances/mission/mission_components/cruise.py
+++ b/src/fastga/models/performances/mission/mission_components/cruise.py
@@ -117,6 +117,7 @@ class ComputeCruise(DynamicEquilibrium):
         atm.true_airspeed = v_tas
         mach = atm.mach
         previous_step = ()
+        self.flight_points = []
 
         while distance_t < cruise_distance:
 

--- a/src/fastga/models/performances/mission/mission_components/descent.py
+++ b/src/fastga/models/performances/mission/mission_components/descent.py
@@ -127,13 +127,15 @@ class ComputeDescent(DynamicEquilibrium):
 
         while altitude_t > 0.0:
 
-            flight_point = oad.FlightPoint(altitude=altitude_t,
-                                           time=time_t,
-                                           ground_distance=distance_t,
-                                           engine_setting=EngineSetting.CLIMB,
-                                           thrust_is_regulated=True,
-                                           mass=mass_t,
-                                           name='sizing:main_route:descent')
+            flight_point = oad.FlightPoint(
+                altitude=altitude_t,
+                time=time_t,
+                ground_distance=distance_t,
+                engine_setting=EngineSetting.CLIMB,
+                thrust_is_regulated=True,
+                mass=mass_t,
+                name="sizing:main_route:descent",
+            )
 
             self.complete_flight_point(flight_point, v_cas=v_cas, climb_rate=descent_rate)
 
@@ -150,13 +152,27 @@ class ComputeDescent(DynamicEquilibrium):
 
             # Find equilibrium, decrease gamma if obtained thrust is negative
             previous_step = self.dynamic_equilibrium(
-                inputs, flight_point.gamma, dynamic_pressure, dvx_dt, 0.0, mass_t, "none", previous_step[0:2]
+                inputs,
+                flight_point.gamma,
+                dynamic_pressure,
+                dvx_dt,
+                0.0,
+                mass_t,
+                "none",
+                previous_step[0:2],
             )
             thrust = previous_step[1]
             while thrust < 0.0:
                 flight_point.gamma = 0.9 * flight_point.gamma
                 previous_step = self.dynamic_equilibrium(
-                    inputs, flight_point.gamma, dynamic_pressure, dvx_dt, 0.0, mass_t, "none", previous_step[0:2]
+                    inputs,
+                    flight_point.gamma,
+                    dynamic_pressure,
+                    dvx_dt,
+                    0.0,
+                    mass_t,
+                    "none",
+                    previous_step[0:2],
                 )
                 thrust = previous_step[1]
 

--- a/src/fastga/models/performances/mission/mission_components/descent.py
+++ b/src/fastga/models/performances/mission/mission_components/descent.py
@@ -113,6 +113,7 @@ class ComputeDescent(DynamicEquilibrium):
         mass_fuel_t = 0.0
         mass_t = mtow - (m_to + m_tk + m_ic + m_cl + m_cr)
         previous_step = ()
+        self.flight_points = []
 
         # Calculate constant speed (cos(gamma)~1) and corresponding descent angle
         # FIXME: VCAS constant-speed strategy is specific to ICE-propeller configuration, should be
@@ -165,6 +166,7 @@ class ComputeDescent(DynamicEquilibrium):
             flight_point.thrust = thrust
             # Compute consumption
             propulsion_model.compute_flight_points(flight_point)
+
             # Save results
             self.add_flight_point(flight_point=flight_point, equilibrium_result=previous_step)
             consumed_mass_1s = propulsion_model.get_consumed_mass(flight_point, 1.0)

--- a/src/fastga/models/variable_descriptions.txt
+++ b/src/fastga/models/variable_descriptions.txt
@@ -81,7 +81,9 @@ settings:weight:aircraft:CG:fwd:MAC_position:margin || safety margin fwd of the 
 settings:weight:aircraft:CG:range || distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG potentially fwd of the computed one, as currently, FAST-OAD uses the aft position of CG as a reference)
 settings:weight:aircraft:payload:design_mass_per_passenger || design payload mass carried by passenger
 settings:weight:aircraft:payload:max_mass_per_passenger || maximum payload mass carried by passenger
-settings:weight:airframe:landing_gear:front:weight_ratio || part of aircraft weight that is supported by front landing gear
+settings:weight:airframe:landing_gear:front:weight_ratio || part of aircraft weight that is supported by front landing gear, should not be lower than 0.08. Roskam
+settings:weight:airframe:landing_gear:front:front_fuselage_ratio || Position of front landing gear expressed as fuselage front length ratio
+settings:weight:propulsion:engine:k_factor || Engine weight tuning factor
 
 settings:geometry:fuel_tanks:depth || ratio of the tank depth as a percentage of the wing depth
 

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
@@ -44,12 +44,10 @@ class ComputeLandingGearCG(ExplicitComponent):
         self.add_input(
             "settings:weight:airframe:landing_gear:front:weight_ratio",
             val=0.3,
-            desc="Should not be lower than 0.08. Roskam",
         )
         self.add_input(
             "settings:weight:airframe:landing_gear:front:front_fuselage_ratio",
             val=0.75,
-            desc="Position of front landing gear expressed as fuselage front length ratio",
         )
 
         self.add_output("data:weight:airframe:landing_gear:front:CG:x", units="m")

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
@@ -41,10 +41,16 @@ class ComputeLandingGearCG(ExplicitComponent):
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:MAC:at25percent:x", val=np.nan, units="m")
         self.add_input("data:weight:aircraft:CG:aft:MAC_position", val=np.nan)
-        self.add_input("settings:weight:airframe:landing_gear:front:weight_ratio", val=0.3,
-                       desc="Should not be lower than 0.08. Roskam")
-        self.add_input("settings:weight:airframe:landing_gear:front:front_fuselage_ratio", val=0.75,
-                       desc="Position of front landing gear expressed as fuselage front length ratio")
+        self.add_input(
+            "settings:weight:airframe:landing_gear:front:weight_ratio",
+            val=0.3,
+            desc="Should not be lower than 0.08. Roskam",
+        )
+        self.add_input(
+            "settings:weight:airframe:landing_gear:front:front_fuselage_ratio",
+            val=0.75,
+            desc="Position of front landing gear expressed as fuselage front length ratio",
+        )
 
         self.add_output("data:weight:airframe:landing_gear:front:CG:x", units="m")
         self.add_output("data:weight:airframe:landing_gear:main:CG:x", units="m")
@@ -67,7 +73,9 @@ class ComputeLandingGearCG(ExplicitComponent):
         fa_length = inputs["data:geometry:wing:MAC:at25percent:x"]
         cg_ratio = inputs["data:weight:aircraft:CG:aft:MAC_position"]
         front_lg_weight_ratio = inputs["settings:weight:airframe:landing_gear:front:weight_ratio"]
-        front_lg_fuselage = inputs["settings:weight:airframe:landing_gear:front:front_fuselage_ratio"]
+        front_lg_fuselage = inputs[
+            "settings:weight:airframe:landing_gear:front:front_fuselage_ratio"
+        ]
 
         # NLG gravity center
         x_cg_a52 = lav * front_lg_fuselage
@@ -84,7 +92,9 @@ class ComputeLandingGearCG(ExplicitComponent):
         l0_wing = inputs["data:geometry:wing:MAC:length"]
         fa_length = inputs["data:geometry:wing:MAC:at25percent:x"]
         cg_ratio = inputs["data:weight:aircraft:CG:aft:MAC_position"]
-        front_lg_fuselage = inputs["settings:weight:airframe:landing_gear:front:front_fuselage_ratio"]
+        front_lg_fuselage = inputs[
+            "settings:weight:airframe:landing_gear:front:front_fuselage_ratio"
+        ]
         # NLG gravity center
         x_cg_a52 = lav * front_lg_fuselage
         # Aft most CG position

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
@@ -41,7 +41,10 @@ class ComputeLandingGearCG(ExplicitComponent):
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:MAC:at25percent:x", val=np.nan, units="m")
         self.add_input("data:weight:aircraft:CG:aft:MAC_position", val=np.nan)
-        self.add_input("settings:weight:airframe:landing_gear:front:weight_ratio", val=0.3)
+        self.add_input("settings:weight:airframe:landing_gear:front:weight_ratio", val=0.3,
+                       desc="Should not be lower than 0.08. Roskam")
+        self.add_input("settings:weight:airframe:landing_gear:front:front_fuselage_ratio", val=0.75,
+                       desc="Position of front landing gear expressed as fuselage front length ratio")
 
         self.add_output("data:weight:airframe:landing_gear:front:CG:x", units="m")
         self.add_output("data:weight:airframe:landing_gear:main:CG:x", units="m")
@@ -64,9 +67,10 @@ class ComputeLandingGearCG(ExplicitComponent):
         fa_length = inputs["data:geometry:wing:MAC:at25percent:x"]
         cg_ratio = inputs["data:weight:aircraft:CG:aft:MAC_position"]
         front_lg_weight_ratio = inputs["settings:weight:airframe:landing_gear:front:weight_ratio"]
+        front_lg_fuselage = inputs["settings:weight:airframe:landing_gear:front:front_fuselage_ratio"]
 
         # NLG gravity center
-        x_cg_a52 = lav * 0.75
+        x_cg_a52 = lav * front_lg_fuselage
         # Aft most CG position
         x_cg_aft = fa_length + (cg_ratio - 0.25) * l0_wing
         x_cg_a51 = (x_cg_aft - front_lg_weight_ratio * x_cg_a52) / (1.0 - front_lg_weight_ratio)
@@ -80,19 +84,20 @@ class ComputeLandingGearCG(ExplicitComponent):
         l0_wing = inputs["data:geometry:wing:MAC:length"]
         fa_length = inputs["data:geometry:wing:MAC:at25percent:x"]
         cg_ratio = inputs["data:weight:aircraft:CG:aft:MAC_position"]
+        front_lg_fuselage = inputs["settings:weight:airframe:landing_gear:front:front_fuselage_ratio"]
         # NLG gravity center
-        x_cg_a52 = lav * 0.75
+        x_cg_a52 = lav * front_lg_fuselage
         # Aft most CG position
         x_cg_aft = fa_length + (cg_ratio - 0.25) * l0_wing
         front_lg_weight_ratio = inputs["settings:weight:airframe:landing_gear:front:weight_ratio"]
 
         partials[
             "data:weight:airframe:landing_gear:front:CG:x", "data:geometry:fuselage:front_length"
-        ] = 0.75
+        ] = front_lg_fuselage
 
         partials[
             "data:weight:airframe:landing_gear:main:CG:x", "data:geometry:fuselage:front_length"
-        ] = (-0.75 * front_lg_weight_ratio / (1.0 - front_lg_weight_ratio))
+        ] = (-front_lg_fuselage * front_lg_weight_ratio / (1.0 - front_lg_weight_ratio))
         partials["data:weight:airframe:landing_gear:main:CG:x", "data:geometry:wing:MAC:length"] = (
             cg_ratio - 0.25
         ) / (1.0 - front_lg_weight_ratio)

--- a/src/fastga/models/weight/cg/unitary_tests/data/beechcraft_76.xml
+++ b/src/fastga/models/weight/cg/unitary_tests/data/beechcraft_76.xml
@@ -806,10 +806,14 @@
           <max_mass_per_passenger units="kg" is_input="True">90.0<!--maximum payload mass carried by passenger--></max_mass_per_passenger>
         </payload>
       </aircraft>
+      <propulsion>
+        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+      </propulsion>
       <airframe>
         <landing_gear>
           <front>
             <weight_ratio is_input="True">0.23<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--> </front_fuselage_ratio>
           </front>
         </landing_gear>
       </airframe>

--- a/src/fastga/models/weight/cg/unitary_tests/data/cirrus_sr22.xml
+++ b/src/fastga/models/weight/cg/unitary_tests/data/cirrus_sr22.xml
@@ -810,9 +810,13 @@
         <landing_gear>
           <front>
             <weight_ratio is_input="True">0.075<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--> </front_fuselage_ratio>
           </front>
         </landing_gear>
       </airframe>
+      <propulsion>
+        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+      </propulsion>
     </weight>
   </settings>
 </FASTOAD_model>

--- a/src/fastga/models/weight/cg/unitary_tests/data/daher_tbm900.xml
+++ b/src/fastga/models/weight/cg/unitary_tests/data/daher_tbm900.xml
@@ -1083,6 +1083,7 @@
         <landing_gear>
           <front>
             <weight_ratio is_input="True">0.24<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--> </front_fuselage_ratio>
           </front>
         </landing_gear>
       </airframe>
@@ -1092,6 +1093,7 @@
             <from_wingMAC25 is_input="True">0.0<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
           </CG>
         </tank>
+        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
       </propulsion>
     </weight>
     <wing>

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -47,7 +47,7 @@ class ComputeEngineWeight(ExplicitComponent):
         self._engine_wrapper.setup(self)
 
         self.add_input(
-            "settings:weight:propulsion:k_b1", val=np.nan, desc="Engine weight tunning factor"
+            "settings:weight:propulsion:engine:k_factor", val=1.0
         )
 
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
@@ -60,7 +60,7 @@ class ComputeEngineWeight(ExplicitComponent):
 
         # This should give the UNINSTALLED weight
         uninstalled_engine_weight = propulsion_model.compute_weight()
-        k_b1 = inputs["settings:weight:propulsion:k_b1"]
+        k_b1 = inputs["settings:weight:propulsion:engine:k_factor"]
 
         b1 = 1.4 * uninstalled_engine_weight
 
@@ -90,7 +90,7 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
         self._engine_wrapper.setup(self)
 
         self.add_input(
-            "settings:weight:propulsion:k_b1", val=np.nan, desc="Engine weight tuning factor"
+            "settings:weight:propulsion:engine:k_factor", val=1.0
         )
 
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
@@ -101,7 +101,7 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
 
         propulsion_model = self._engine_wrapper.get_model(inputs)
 
-        k_b1 = inputs["settings:weight:propulsion:k_b1"]
+        k_b1 = inputs["settings:weight:propulsion:engine:k_factor"]
 
         # This should give the UNINSTALLED weight in lbs !
         uninstalled_engine_weight = propulsion_model.compute_weight()

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -46,7 +46,9 @@ class ComputeEngineWeight(ExplicitComponent):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
         self._engine_wrapper.setup(self)
 
-        self.add_input("settings:weight:propulsion:k_b1", val=np.nan, desc='Engine weight tunning factor')
+        self.add_input(
+            "settings:weight:propulsion:k_b1", val=np.nan, desc="Engine weight tunning factor"
+        )
 
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
 
@@ -87,7 +89,9 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
         self._engine_wrapper.setup(self)
 
-        self.add_input("settings:weight:propulsion:k_b1", val=np.nan, desc='Engine weight tuning factor')
+        self.add_input(
+            "settings:weight:propulsion:k_b1", val=np.nan, desc="Engine weight tuning factor"
+        )
 
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
 

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -12,13 +12,13 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
 import fastoad.api as oad
+
 from .constants import SUBMODEL_INSTALLED_ENGINE_MASS
-import numpy as np
 
 oad.RegisterSubmodel.active_models[
     SUBMODEL_INSTALLED_ENGINE_MASS
@@ -28,7 +28,7 @@ oad.RegisterSubmodel.active_models[
 @oad.RegisterSubmodel(
     SUBMODEL_INSTALLED_ENGINE_MASS, "fastga.submodel.weight.mass.propulsion.installed_engine.legacy"
 )
-class ComputeEngineWeight(ExplicitComponent):
+class ComputeEngineWeight(om.ExplicitComponent):
     """
     Engine weight estimation calling wrapper
 
@@ -60,15 +60,15 @@ class ComputeEngineWeight(ExplicitComponent):
         uninstalled_engine_weight = propulsion_model.compute_weight()
         k_b1 = inputs["settings:weight:propulsion:engine:k_factor"]
 
-        b1 = 1.4 * uninstalled_engine_weight
+        b_1 = 1.4 * uninstalled_engine_weight
 
-        outputs["data:weight:propulsion:engine:mass"] = b1 * k_b1
+        outputs["data:weight:propulsion:engine:mass"] = b_1 * k_b1
 
 
 @oad.RegisterSubmodel(
     SUBMODEL_INSTALLED_ENGINE_MASS, "fastga.submodel.weight.mass.propulsion.installed_engine.raymer"
 )
-class ComputeEngineWeightRaymer(ExplicitComponent):
+class ComputeEngineWeightRaymer(om.ExplicitComponent):
     """
     Engine weight estimation calling wrapper
 
@@ -102,6 +102,6 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
         # This should give the UNINSTALLED weight in lbs !
         uninstalled_engine_weight = propulsion_model.compute_weight()
 
-        b1 = 2.575 * uninstalled_engine_weight ** 0.922
+        b_1 = 2.575 * uninstalled_engine_weight ** 0.922
 
-        outputs["data:weight:propulsion:engine:mass"] = b1 * k_b1
+        outputs["data:weight:propulsion:engine:mass"] = b_1 * k_b1

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -46,9 +46,7 @@ class ComputeEngineWeight(ExplicitComponent):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
         self._engine_wrapper.setup(self)
 
-        self.add_input(
-            "settings:weight:propulsion:engine:k_factor", val=1.0
-        )
+        self.add_input("settings:weight:propulsion:engine:k_factor", val=1.0)
 
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
 
@@ -89,9 +87,7 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
         self._engine_wrapper.setup(self)
 
-        self.add_input(
-            "settings:weight:propulsion:engine:k_factor", val=1.0
-        )
+        self.add_input("settings:weight:propulsion:engine:k_factor", val=1.0)
 
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
 

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -18,6 +18,7 @@ from openmdao.core.explicitcomponent import ExplicitComponent
 from fastoad.module_management._bundle_loader import BundleLoader
 import fastoad.api as oad
 from .constants import SUBMODEL_INSTALLED_ENGINE_MASS
+import numpy as np
 
 oad.RegisterSubmodel.active_models[
     SUBMODEL_INSTALLED_ENGINE_MASS
@@ -45,6 +46,8 @@ class ComputeEngineWeight(ExplicitComponent):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
         self._engine_wrapper.setup(self)
 
+        self.add_input("settings:weight:propulsion:k_b1", val=np.nan, desc='Engine weight tunning factor')
+
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
 
         self.declare_partials("*", "*", method="fd")
@@ -55,10 +58,11 @@ class ComputeEngineWeight(ExplicitComponent):
 
         # This should give the UNINSTALLED weight
         uninstalled_engine_weight = propulsion_model.compute_weight()
+        k_b1 = inputs["settings:weight:propulsion:k_b1"]
 
         b1 = 1.4 * uninstalled_engine_weight
 
-        outputs["data:weight:propulsion:engine:mass"] = b1
+        outputs["data:weight:propulsion:engine:mass"] = b1 * k_b1
 
 
 @oad.RegisterSubmodel(
@@ -83,6 +87,8 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
         self._engine_wrapper.setup(self)
 
+        self.add_input("settings:weight:propulsion:k_b1", val=np.nan, desc='Engine weight tuning factor')
+
         self.add_output("data:weight:propulsion:engine:mass", units="lb")
 
         self.declare_partials("*", "*", method="fd")
@@ -90,11 +96,12 @@ class ComputeEngineWeightRaymer(ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 
         propulsion_model = self._engine_wrapper.get_model(inputs)
-        engine_count = inputs["data:geometry:propulsion:engine:count"]
+
+        k_b1 = inputs["settings:weight:propulsion:k_b1"]
 
         # This should give the UNINSTALLED weight in lbs !
         uninstalled_engine_weight = propulsion_model.compute_weight()
 
-        b1 = 2.575 * uninstalled_engine_weight ** 0.922 * engine_count
+        b1 = 2.575 * uninstalled_engine_weight ** 0.922
 
-        outputs["data:weight:propulsion:engine:mass"] = b1
+        outputs["data:weight:propulsion:engine:mass"] = b1 * k_b1

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/data/beechcraft_76.xml
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/data/beechcraft_76.xml
@@ -893,7 +893,9 @@
         </payload>
       </aircraft>
       <propulsion>
-        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+        <engine>
+          <k_factor is_input="True">1.0<!--Engine weight tuning factor--></k_factor>
+        </engine>
       </propulsion>
       <airframe>
         <fuselage>

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/data/beechcraft_76.xml
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/data/beechcraft_76.xml
@@ -892,6 +892,9 @@
           <max_mass_per_passenger units="kg" is_input="True">90.0<!--maximum payload mass carried by passenger--></max_mass_per_passenger>
         </payload>
       </aircraft>
+      <propulsion>
+        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+      </propulsion>
       <airframe>
         <fuselage>
           <reinforcements>
@@ -901,6 +904,7 @@
         <landing_gear>
           <front>
             <weight_ratio is_input="True">0.23<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--> </front_fuselage_ratio>
           </front>
         </landing_gear>
       </airframe>

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/data/cirrus_sr22.xml
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/data/cirrus_sr22.xml
@@ -915,9 +915,13 @@
         <landing_gear>
           <front>
             <weight_ratio is_input="True">0.075<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--> </front_fuselage_ratio>
           </front>
         </landing_gear>
       </airframe>
+      <propulsion>
+        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+      </propulsion>
     </weight>
   </settings>
 </FASTOAD_model>

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/data/cirrus_sr22.xml
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/data/cirrus_sr22.xml
@@ -920,7 +920,9 @@
         </landing_gear>
       </airframe>
       <propulsion>
-        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+        <engine>
+          <k_factor is_input="True">1.0<!--Engine weight tuning factor--></k_factor>
+        </engine>
       </propulsion>
     </weight>
   </settings>

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/data/daher_tbm900.xml
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/data/daher_tbm900.xml
@@ -1082,6 +1082,7 @@
         <landing_gear>
           <front>
             <weight_ratio is_input="True">0.24<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <front_fuselage_ratio is_input="True">0.75<!--Position of front landing gear expressed as fuselage front length ratio--> </front_fuselage_ratio>
           </front>
         </landing_gear>
       </airframe>
@@ -1091,6 +1092,7 @@
             <from_wingMAC25 is_input="True">0.0<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
           </CG>
         </tank>
+        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
       </propulsion>
     </weight>
     <wing>

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/data/daher_tbm900.xml
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/data/daher_tbm900.xml
@@ -1092,7 +1092,9 @@
             <from_wingMAC25 is_input="True">0.0<!--distance between the tank CG and 25 percent of wing MAC as a ratio of the wing MAC--></from_wingMAC25>
           </CG>
         </tank>
-        <k_b1 is_input="True">1.0<!--Engine weight tuning factor--></k_b1>
+        <engine>
+          <k_factor is_input="True">1.0<!--Engine weight tuning factor--></k_factor>
+        </engine>
       </propulsion>
     </weight>
     <wing>

--- a/src/fastga/models/weight/mass_breakdown/unitary_tests/test_beechcraft_76.py
+++ b/src/fastga/models/weight/mass_breakdown/unitary_tests/test_beechcraft_76.py
@@ -431,7 +431,7 @@ def test_compute_engine_weight_raymer():
     # Run problem and check obtained value(s) is/(are) correct
     problem = run_system(ComputeEngineWeightRaymer(propulsion_id=ENGINE_WRAPPER), ivc)
     weight_b1 = problem.get_val("data:weight:propulsion:engine:mass", units="kg")
-    assert weight_b1 == pytest.approx(802.27, abs=1e-2)
+    assert weight_b1 == pytest.approx(401.13, abs=1e-2)
 
 
 def test_compute_fuel_lines_weight():

--- a/src/fastga/notebooks/tutorial/data/beechcraft_76.xml
+++ b/src/fastga/notebooks/tutorial/data/beechcraft_76.xml
@@ -203,6 +203,9 @@
           </front>
         </landing_gear>
       </airframe>
+      <propulsion>
+        <k_b1 is_input="True">1.0<!--Engine weight tunning factor--></k_b1>
+      </propulsion>
     </weight>
   </settings>
 </FASTOAD_model>

--- a/src/fastga/notebooks/tutorial/data/beechcraft_76.xml
+++ b/src/fastga/notebooks/tutorial/data/beechcraft_76.xml
@@ -204,7 +204,9 @@
         </landing_gear>
       </airframe>
       <propulsion>
-        <k_b1 is_input="True">1.0<!--Engine weight tunning factor--></k_b1>
+        <engine>
+          <k_factor is_input="True">1.0<!--Engine weight tuning factor--></k_factor>
+        </engine>
       </propulsion>
     </weight>
   </settings>

--- a/src/fastga/notebooks/tutorial/data/beechcraft_76_loads.xml
+++ b/src/fastga/notebooks/tutorial/data/beechcraft_76_loads.xml
@@ -266,6 +266,9 @@
           </front>
         </landing_gear>
       </airframe>
+      <propulsion>
+        <k_b1 is_input="True">nan<!--Engine weight tunning factor--></k_b1>
+      </propulsion>
     </weight>
   </settings>
 </FASTOAD_model>

--- a/src/fastga/notebooks/tutorial/data/beechcraft_76_loads.xml
+++ b/src/fastga/notebooks/tutorial/data/beechcraft_76_loads.xml
@@ -267,7 +267,7 @@
         </landing_gear>
       </airframe>
       <propulsion>
-        <k_b1 is_input="True">nan<!--Engine weight tunning factor--></k_b1>
+        <k_b1 is_input="True">1.0<!--Engine weight tunning factor--></k_b1>
       </propulsion>
     </weight>
   </settings>

--- a/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
+++ b/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
@@ -244,7 +244,7 @@
         </landing_gear>
       </airframe>
       <propulsion>
-        <k_b1 is_input="True">nan<!--Engine weight tunning factor--></k_b1>
+        <k_b1 is_input="True">1.0<!--Engine weight tunning factor--></k_b1>
       </propulsion>
     </weight>
   </settings>

--- a/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
+++ b/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
@@ -243,6 +243,9 @@
           </front>
         </landing_gear>
       </airframe>
+      <propulsion>
+        <k_b1 is_input="True">nan<!--Engine weight tunning factor--></k_b1>
+      </propulsion>
     </weight>
   </settings>
 </FASTOAD_model>

--- a/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
+++ b/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
@@ -244,7 +244,9 @@
         </landing_gear>
       </airframe>
       <propulsion>
-        <k_b1 is_input="True">1.0<!--Engine weight tunning factor--></k_b1>
+        <engine>
+          <k_factor is_input="True">1.0<!--Engine weight tuning factor--></k_factor>
+        </engine>
       </propulsion>
     </weight>
   </settings>


### PR DESCRIPTION
The major modification is the usage of [FlightPoint dataclass](https://github.com/fast-aircraft-design/FAST-OAD/blob/master/src/fastoad/model_base/flight_point.py) of FAST-OAD to handle and save the mission flight points in csv file. To add more variable to the .csv file, instead of manually adding a new variable to the saving functions in the mission files, it can be added from any file by extending the FlightPoint dataclass (see doc [here](https://fast-oad.readthedocs.io/en/v1.4.0/documentation/mission_module/extensibility/flight_point.html#extensibility) ) and completing the field of the FlightPoint instance. This can be done directly in the propulsion model for example, without intervention in the mission files.

Minor modifications includes:
-Addition of a engine weight tuning factor (k_b1)
-Addition of the position of the front landing gear as input (instead of hard coded)
-Fix potential bug in submodule: Roskam engine weight.