### PR TITLE
Dev issue 188

### DIFF
--- a/src/fastga/models/aerodynamics/components/compute_cl_aileron.py
+++ b/src/fastga/models/aerodynamics/components/compute_cl_aileron.py
@@ -87,7 +87,7 @@ class ComputeClDeltaAileron(FigureDigitization):
 
         # Aileron are most mostly going to be used around delta_a = 0 degree, which is the reason
         # why the effectiveness is going to be computed around this deflection
-        alpha_aileron = self.k_prime_single_slotted(0.0, aileron_chord_ratio)
+        alpha_aileron = self.k_prime_single_slotted(0.0, float(aileron_chord_ratio))
         lift_increase_aileron = 2 * np.pi / np.sqrt(1 - mach ** 2) * alpha_aileron
 
         cl_delta_a = (

--- a/src/fastga/models/aerodynamics/components/compute_cy_rudder.py
+++ b/src/fastga/models/aerodynamics/components/compute_cy_rudder.py
@@ -64,10 +64,10 @@ class ComputeCyDeltaRudder(FigureDigitization):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 
         taper_ratio_vt = inputs["data:geometry:vertical_tail:taper_ratio"]
-        aspect_ratio_vt = float(inputs["data:geometry:vertical_tail:aspect_ratio"])
+        aspect_ratio_vt = inputs["data:geometry:vertical_tail:aspect_ratio"]
         thickness_ratio_vt = inputs["data:geometry:vertical_tail:thickness_ratio"]
         rudder_chord_ratio = inputs["data:geometry:vertical_tail:rudder:chord_ratio"]
-        k_ar_effective = float(inputs["data:aerodynamics:vertical_tail:k_ar_effective"])
+        k_ar_effective = inputs["data:aerodynamics:vertical_tail:k_ar_effective"]
 
         if self.options["low_speed_aero"]:
             cl_alpha_vt = inputs["data:aerodynamics:vertical_tail:low_speed:CL_alpha"]
@@ -80,12 +80,12 @@ class ComputeCyDeltaRudder(FigureDigitization):
         # small gap at the bottom and at the top
         eta_in = 0.05
         eta_out = 0.95
-        kb = self.k_b_flaps(eta_in, eta_out, taper_ratio_vt)
+        kb = self.k_b_flaps(eta_in, eta_out, float(taper_ratio_vt))
 
         # Interpolation of the first graph of figure 8.53 of Roskam
-        rudder_effectiveness_parameter = self.a_delta_airfoil(rudder_chord_ratio)
+        rudder_effectiveness_parameter = self.a_delta_airfoil(float(rudder_chord_ratio))
         k_a_delta = self.k_a_delta(
-            float(rudder_effectiveness_parameter), k_ar_effective * aspect_ratio_vt
+            float(rudder_effectiveness_parameter), float(k_ar_effective * aspect_ratio_vt)
         )
 
         k_cl_delta = self.k_cl_delta_plain_flap(

--- a/src/fastga/models/aerodynamics/components/compute_cy_rudder.py
+++ b/src/fastga/models/aerodynamics/components/compute_cy_rudder.py
@@ -65,7 +65,7 @@ class ComputeCyDeltaRudder(FigureDigitization):
 
         taper_ratio_vt = inputs["data:geometry:vertical_tail:taper_ratio"]
         aspect_ratio_vt = float(inputs["data:geometry:vertical_tail:aspect_ratio"])
-        thickness_ratio_vt = float(inputs["data:geometry:vertical_tail:thickness_ratio"])
+        thickness_ratio_vt = inputs["data:geometry:vertical_tail:thickness_ratio"]
         rudder_chord_ratio = inputs["data:geometry:vertical_tail:rudder:chord_ratio"]
         k_ar_effective = float(inputs["data:aerodynamics:vertical_tail:k_ar_effective"])
 
@@ -89,10 +89,12 @@ class ComputeCyDeltaRudder(FigureDigitization):
         )
 
         k_cl_delta = self.k_cl_delta_plain_flap(
-            thickness_ratio_vt, cl_alpha_vt_airfoil, rudder_chord_ratio
+            float(thickness_ratio_vt), float(cl_alpha_vt_airfoil), float(rudder_chord_ratio)
         )
 
-        cl_delta_th = self.cl_delta_theory_plain_flap(thickness_ratio_vt, rudder_chord_ratio)
+        cl_delta_th = self.cl_delta_theory_plain_flap(
+            float(thickness_ratio_vt), float(rudder_chord_ratio)
+        )
 
         cy_delta_r = cl_alpha_vt / cl_alpha_vt_airfoil * kb * k_a_delta * k_cl_delta * cl_delta_th
 

--- a/src/fastga/models/aerodynamics/components/elevator_aero.py
+++ b/src/fastga/models/aerodynamics/components/elevator_aero.py
@@ -90,10 +90,12 @@ class ComputeDeltaElevator(FigureDigitization):
         cl_alpha_airfoil_ht = inputs["data:aerodynamics:horizontal_tail:airfoil:CL_alpha"]
 
         # Elevator (plain flap). Default: maximum deflection (25deg)
-        cl_delta_theory = self.cl_delta_theory_plain_flap(htp_thickness_ratio, elevator_chord_ratio)
-        k = self.k_prime_plain_flap(abs(elevator_angle), elevator_chord_ratio)
+        cl_delta_theory = self.cl_delta_theory_plain_flap(
+            float(htp_thickness_ratio), float(elevator_chord_ratio)
+        )
+        k = self.k_prime_plain_flap(abs(float(elevator_angle)), float(elevator_chord_ratio))
         k_cl_delta = self.k_cl_delta_plain_flap(
-            htp_thickness_ratio, cl_alpha_airfoil_ht, elevator_chord_ratio
+            float(htp_thickness_ratio), float(cl_alpha_airfoil_ht), float(elevator_chord_ratio)
         )
         cl_alpha_elev = (cl_delta_theory * k * k_cl_delta) * ht_area / wing_area
         cl_alpha_elev *= 0.9  # Correction for the central fuselage part (no elevator there)

--- a/src/fastga/models/aerodynamics/components/elevator_aero.py
+++ b/src/fastga/models/aerodynamics/components/elevator_aero.py
@@ -53,6 +53,7 @@ class ComputeDeltaElevator(FigureDigitization):
 
         wing_area = inputs["data:geometry:wing:area"]
         htp_area = inputs["data:geometry:horizontal_tail:area"]
+        elevator_chord_ratio = inputs["data:geometry:horizontal_tail:elevator_chord_ratio"]
 
         # Computes elevator contribution during low speed operations (for different deflection
         # angle)
@@ -63,8 +64,8 @@ class ComputeDeltaElevator(FigureDigitization):
         # derivative wrt to the wing, multiplies the deflection angle squared
         outputs["data:aerodynamics:elevator:low_speed:CD_delta"] = (
             self.delta_cd_plain_flap(
-                inputs["data:geometry:horizontal_tail:elevator_chord_ratio"],
-                abs(inputs["data:mission:sizing:landing:elevator_angle"]),
+                float(elevator_chord_ratio),
+                abs(float(inputs["data:mission:sizing:landing:elevator_angle"])),
             )
             / (abs(inputs["data:mission:sizing:landing:elevator_angle"]) * np.pi / 180.0) ** 2.0
             * np.cos(inputs["data:geometry:horizontal_tail:sweep_25"])

--- a/src/fastga/models/aerodynamics/components/figure_digitization.py
+++ b/src/fastga/models/aerodynamics/components/figure_digitization.py
@@ -76,6 +76,7 @@ class FigureDigitization(om.ExplicitComponent):
         self.phase = None
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def delta_cd_plain_flap(chord_ratio, control_deflection) -> float:
         """
         Roskam data to account for the profile drag increment due to the deployment of plain flap
@@ -1129,6 +1130,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_vh
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def k_ch_alpha(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to compute the correction factor to differentiate the 2D control surface hinge
@@ -1187,6 +1189,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_ch_alpha
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def ch_alpha_th(thickness_ratio, chord_ratio):
         """
         Roskam data to compute the theoretical 2D control surface hinge moment derivative due to
@@ -1235,6 +1238,7 @@ class FigureDigitization(om.ExplicitComponent):
         return ch_alpha_th
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def k_ch_delta(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to compute the correction factor to differentiate the 2D control surface
@@ -1305,6 +1309,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_ch_delta
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def ch_delta_th(thickness_ratio, chord_ratio):
         """
         Roskam data to compute the theoretical 2D control surface hinge moment derivative due to

--- a/src/fastga/models/aerodynamics/components/figure_digitization.py
+++ b/src/fastga/models/aerodynamics/components/figure_digitization.py
@@ -76,7 +76,7 @@ class FigureDigitization(om.ExplicitComponent):
         self.phase = None
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def delta_cd_plain_flap(chord_ratio, control_deflection) -> float:
         """
         Roskam data to account for the profile drag increment due to the deployment of plain flap
@@ -127,7 +127,7 @@ class FigureDigitization(om.ExplicitComponent):
         return delta_cd_flap
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_prime_plain_flap(flap_angle, chord_ratio):
         """
         Roskam data to estimate the correction factor to estimate non linear lift behaviour of
@@ -211,7 +211,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_prime
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def cl_delta_theory_plain_flap(thickness, chord_ratio):
         """
         Roskam data to estimate the theoretical airfoil lift effectiveness of a plain flap (
@@ -279,7 +279,7 @@ class FigureDigitization(om.ExplicitComponent):
         return cl_delta_th
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_cl_delta_plain_flap(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to estimate the correction factor to estimate difference from theoretical
@@ -340,7 +340,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_cl_delta
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_prime_single_slotted(flap_angle, chord_ratio):
         """
         Roskam data to estimate the lift effectiveness of a single slotted flap (figure 8.17),
@@ -421,7 +421,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_prime
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def base_max_lift_increment(thickness_ratio: float, flap_type: float) -> float:
         """
         Roskam data to estimate base lift increment used in the computation of flap delta_cl_max
@@ -476,7 +476,7 @@ class FigureDigitization(om.ExplicitComponent):
         return delta_cl_max_base
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k1_max_lift(chord_ratio, flap_type) -> float:
         """
         Roskam data to correct the base lift increment to account for chord ratio difference wrt
@@ -518,7 +518,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k1
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k2_max_lift(angle, flap_type) -> float:
         """
         Roskam data to correct the base lift increment to account for the control surface
@@ -575,7 +575,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k2
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k3_max_lift(angle, flap_type) -> float:
         """
         Roskam data for flap motion correction factor (figure 8.34).
@@ -614,7 +614,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k3
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_b_flaps(eta_in: float, eta_out: float, taper_ratio: float) -> float:
         """
         Roskam data to estimate the flap span factor Kb (figure 8.52) This factor accounts for a
@@ -694,7 +694,7 @@ class FigureDigitization(om.ExplicitComponent):
         return float(kb_out - kb_in)
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def a_delta_airfoil(chord_ratio) -> float:
         """
         Roskam data to estimate the two-dimensional flap effectiveness factor (figure 8.53a) This
@@ -725,7 +725,7 @@ class FigureDigitization(om.ExplicitComponent):
         return a_delta
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_a_delta(a_delta_airfoil, aspect_ratio) -> float:
         """
         Roskam data to estimate the two dimensional to three dimensional control surface lift
@@ -828,7 +828,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_a_delta
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def x_cp_c_prime(flap_chord_ratio: float) -> float:
         """
         Roskam data to estimate the location of the center of pressure due to Incremental Flap
@@ -850,7 +850,7 @@ class FigureDigitization(om.ExplicitComponent):
         return x_cp_c_prime
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_p_flaps(taper_ratio, eta_in, eta_out) -> float:
         """
         Roskam data to account for the partial span flaps factor on the pitch moment coefficient
@@ -907,7 +907,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_p
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def pitch_to_reference_lift(thickness_ratio: float, chord_ratio: float) -> float:
         """
         Roskam data to account for the ratio between the pitch moment coefficient and the
@@ -987,7 +987,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_delta_flaps(taper_ratio: float, eta_in: float, eta_out: float) -> float:
         """
         Roskam data to estimate the conversion factor which accounts for partial span flaps on a
@@ -1130,7 +1130,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_vh
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_ch_alpha(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to compute the correction factor to differentiate the 2D control surface hinge
@@ -1189,7 +1189,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_ch_alpha
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def ch_alpha_th(thickness_ratio, chord_ratio):
         """
         Roskam data to compute the theoretical 2D control surface hinge moment derivative due to
@@ -1238,7 +1238,7 @@ class FigureDigitization(om.ExplicitComponent):
         return ch_alpha_th
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def k_ch_delta(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to compute the correction factor to differentiate the 2D control surface
@@ -1309,7 +1309,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_ch_delta
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
+    @functools.lru_cache(maxsize=128)
     def ch_delta_th(thickness_ratio, chord_ratio):
         """
         Roskam data to compute the theoretical 2D control surface hinge moment derivative due to

--- a/src/fastga/models/aerodynamics/components/figure_digitization.py
+++ b/src/fastga/models/aerodynamics/components/figure_digitization.py
@@ -420,6 +420,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_prime
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def base_max_lift_increment(thickness_ratio: float, flap_type: float) -> float:
         """
         Roskam data to estimate base lift increment used in the computation of flap delta_cl_max
@@ -474,6 +475,7 @@ class FigureDigitization(om.ExplicitComponent):
         return delta_cl_max_base
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k1_max_lift(chord_ratio, flap_type) -> float:
         """
         Roskam data to correct the base lift increment to account for chord ratio difference wrt
@@ -515,6 +517,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k1
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k2_max_lift(angle, flap_type) -> float:
         """
         Roskam data to correct the base lift increment to account for the control surface
@@ -571,6 +574,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k2
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k3_max_lift(angle, flap_type) -> float:
         """
         Roskam data for flap motion correction factor (figure 8.34).
@@ -609,6 +613,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k3
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k_b_flaps(eta_in: float, eta_out: float, taper_ratio: float) -> float:
         """
         Roskam data to estimate the flap span factor Kb (figure 8.52) This factor accounts for a
@@ -688,6 +693,7 @@ class FigureDigitization(om.ExplicitComponent):
         return float(kb_out - kb_in)
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def a_delta_airfoil(chord_ratio) -> float:
         """
         Roskam data to estimate the two-dimensional flap effectiveness factor (figure 8.53a) This
@@ -718,6 +724,7 @@ class FigureDigitization(om.ExplicitComponent):
         return a_delta
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k_a_delta(a_delta_airfoil, aspect_ratio) -> float:
         """
         Roskam data to estimate the two dimensional to three dimensional control surface lift
@@ -809,13 +816,13 @@ class FigureDigitization(om.ExplicitComponent):
         x = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
         y = [y1, y2, y3, y4, y5, y6, y7, y8, y9, y10]
 
-        if float(a_delta_airfoil) != np.clip(float(a_delta_airfoil), 0.0, 1.0):
+        if a_delta_airfoil != np.clip(a_delta_airfoil, 0.0, 1.0):
             _LOGGER.warning(
                 "Control surface effectiveness ratio value outside of the range in "
                 "Roskam's book, value clipped"
             )
 
-        k_a_delta = interpolate.interp1d(x, y)(np.clip(float(a_delta_airfoil), 0.1, 1.0))
+        k_a_delta = interpolate.interp1d(x, y)(np.clip(a_delta_airfoil, 0.1, 1.0))
 
         return k_a_delta
 

--- a/src/fastga/models/aerodynamics/components/figure_digitization.py
+++ b/src/fastga/models/aerodynamics/components/figure_digitization.py
@@ -16,6 +16,7 @@ coefficient of the aircraft.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import functools
 import os.path as pth
 
 import numpy as np
@@ -125,6 +126,7 @@ class FigureDigitization(om.ExplicitComponent):
         return delta_cd_flap
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k_prime_plain_flap(flap_angle, chord_ratio):
         """
         Roskam data to estimate the correction factor to estimate non linear lift behaviour of
@@ -208,6 +210,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_prime
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def cl_delta_theory_plain_flap(thickness, chord_ratio):
         """
         Roskam data to estimate the theoretical airfoil lift effectiveness of a plain flap (
@@ -275,6 +278,7 @@ class FigureDigitization(om.ExplicitComponent):
         return cl_delta_th
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k_cl_delta_plain_flap(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to estimate the correction factor to estimate difference from theoretical
@@ -335,6 +339,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_cl_delta
 
     @staticmethod
+    @functools.lru_cache(maxsize=128)
     def k_prime_single_slotted(flap_angle, chord_ratio):
         """
         Roskam data to estimate the lift effectiveness of a single slotted flap (figure 8.17),

--- a/src/fastga/models/aerodynamics/components/figure_digitization.py
+++ b/src/fastga/models/aerodynamics/components/figure_digitization.py
@@ -827,6 +827,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_a_delta
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def x_cp_c_prime(flap_chord_ratio: float) -> float:
         """
         Roskam data to estimate the location of the center of pressure due to Incremental Flap

--- a/src/fastga/models/aerodynamics/components/figure_digitization.py
+++ b/src/fastga/models/aerodynamics/components/figure_digitization.py
@@ -126,7 +126,7 @@ class FigureDigitization(om.ExplicitComponent):
         return delta_cd_flap
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k_prime_plain_flap(flap_angle, chord_ratio):
         """
         Roskam data to estimate the correction factor to estimate non linear lift behaviour of
@@ -210,7 +210,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_prime
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def cl_delta_theory_plain_flap(thickness, chord_ratio):
         """
         Roskam data to estimate the theoretical airfoil lift effectiveness of a plain flap (
@@ -278,7 +278,7 @@ class FigureDigitization(om.ExplicitComponent):
         return cl_delta_th
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k_cl_delta_plain_flap(thickness_ratio, airfoil_lift_coefficient, chord_ratio):
         """
         Roskam data to estimate the correction factor to estimate difference from theoretical
@@ -339,7 +339,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_cl_delta
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k_prime_single_slotted(flap_angle, chord_ratio):
         """
         Roskam data to estimate the lift effectiveness of a single slotted flap (figure 8.17),
@@ -420,7 +420,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_prime
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def base_max_lift_increment(thickness_ratio: float, flap_type: float) -> float:
         """
         Roskam data to estimate base lift increment used in the computation of flap delta_cl_max
@@ -475,7 +475,7 @@ class FigureDigitization(om.ExplicitComponent):
         return delta_cl_max_base
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k1_max_lift(chord_ratio, flap_type) -> float:
         """
         Roskam data to correct the base lift increment to account for chord ratio difference wrt
@@ -517,7 +517,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k1
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k2_max_lift(angle, flap_type) -> float:
         """
         Roskam data to correct the base lift increment to account for the control surface
@@ -574,7 +574,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k2
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k3_max_lift(angle, flap_type) -> float:
         """
         Roskam data for flap motion correction factor (figure 8.34).
@@ -613,7 +613,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k3
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k_b_flaps(eta_in: float, eta_out: float, taper_ratio: float) -> float:
         """
         Roskam data to estimate the flap span factor Kb (figure 8.52) This factor accounts for a
@@ -693,7 +693,7 @@ class FigureDigitization(om.ExplicitComponent):
         return float(kb_out - kb_in)
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def a_delta_airfoil(chord_ratio) -> float:
         """
         Roskam data to estimate the two-dimensional flap effectiveness factor (figure 8.53a) This
@@ -724,7 +724,7 @@ class FigureDigitization(om.ExplicitComponent):
         return a_delta
 
     @staticmethod
-    @functools.lru_cache(maxsize=128)
+    @functools.lru_cache(maxsize=256)
     def k_a_delta(a_delta_airfoil, aspect_ratio) -> float:
         """
         Roskam data to estimate the two dimensional to three dimensional control surface lift
@@ -848,6 +848,7 @@ class FigureDigitization(om.ExplicitComponent):
         return x_cp_c_prime
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def k_p_flaps(taper_ratio, eta_in, eta_out) -> float:
         """
         Roskam data to account for the partial span flaps factor on the pitch moment coefficient
@@ -904,6 +905,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k_p
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def pitch_to_reference_lift(thickness_ratio: float, chord_ratio: float) -> float:
         """
         Roskam data to account for the ratio between the pitch moment coefficient and the
@@ -983,6 +985,7 @@ class FigureDigitization(om.ExplicitComponent):
         return k
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def k_delta_flaps(taper_ratio: float, eta_in: float, eta_out: float) -> float:
         """
         Roskam data to estimate the conversion factor which accounts for partial span flaps on a

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -155,10 +155,12 @@ class ComputeDeltaHighLift(FigureDigitization):
         cl_alpha_airfoil_ht = inputs["data:aerodynamics:horizontal_tail:airfoil:CL_alpha"]
 
         # Elevator (plain flap). Default: maximum deflection (25deg)
-        cl_delta_theory = self.cl_delta_theory_plain_flap(htp_thickness_ratio, elevator_chord_ratio)
-        k = self.k_prime_plain_flap(abs(elevator_angle), elevator_chord_ratio)
+        cl_delta_theory = self.cl_delta_theory_plain_flap(
+            float(htp_thickness_ratio), float(elevator_chord_ratio)
+        )
+        k = self.k_prime_plain_flap(abs(float(elevator_angle)), float(elevator_chord_ratio))
         k_cl_delta = self.k_cl_delta_plain_flap(
-            htp_thickness_ratio, cl_alpha_airfoil_ht, elevator_chord_ratio
+            float(htp_thickness_ratio), float(cl_alpha_airfoil_ht), float(elevator_chord_ratio)
         )
         cl_alpha_elev = (cl_delta_theory * k * k_cl_delta) * ht_area / wing_area
         cl_alpha_elev *= 0.9  # Correction for the central fuselage part (no elevator there)
@@ -391,23 +393,23 @@ class ComputeDeltaHighLift(FigureDigitization):
         """
 
         flap_type = inputs["data:geometry:flap_type"]
-        flap_chord_ratio = float(inputs["data:geometry:flap:chord_ratio"])
-        wing_thickness_ratio = float(inputs["data:geometry:wing:thickness_ratio"])
+        flap_chord_ratio = inputs["data:geometry:flap:chord_ratio"]
+        wing_thickness_ratio = inputs["data:geometry:wing:thickness_ratio"]
         cl_alpha_airfoil_wing = inputs["data:aerodynamics:wing:airfoil:CL_alpha"]
 
         # 2D flap lift coefficient
         if flap_type == 1:  # Slotted flap
-            alpha_flap = self.k_prime_single_slotted(angle, flap_chord_ratio)
+            alpha_flap = self.k_prime_single_slotted(float(angle), float(flap_chord_ratio))
             delta_cl_airfoil = (
                 2 * np.pi / np.sqrt(1 - mach ** 2) * alpha_flap * (angle * np.pi / 180)
             )
         else:  # Plain flap
             cl_delta_theory = self.cl_delta_theory_plain_flap(
-                wing_thickness_ratio, flap_chord_ratio
+                float(wing_thickness_ratio), float(flap_chord_ratio)
             )
-            k = self.k_prime_plain_flap(abs(angle), flap_chord_ratio)
+            k = self.k_prime_plain_flap(abs(float(angle)), float(flap_chord_ratio))
             k_cl_delta = self.k_cl_delta_plain_flap(
-                wing_thickness_ratio, cl_alpha_airfoil_wing, flap_chord_ratio
+                float(wing_thickness_ratio), float(cl_alpha_airfoil_wing), float(flap_chord_ratio)
             )
             delta_cl_airfoil = k_cl_delta * cl_delta_theory * k * (angle * np.pi / 180)
 

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -11,7 +11,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+import functools
 from typing import Union, Tuple
 
 import numpy as np
@@ -97,7 +97,7 @@ class ComputeDeltaHighLift(FigureDigitization):
                     flap_angle,
                     mach_ls,
                 )
-                x_cp_c_prime = self.x_cp_c_prime(flap_chord_ratio)
+                x_cp_c_prime = self.x_cp_c_prime(float(flap_chord_ratio))
                 outputs["data:aerodynamics:flaps:landing:CM_2D"] = cl_2d * (0.25 - x_cp_c_prime)
                 cd_3d = self._get_flaps_delta_cd(
                     inputs["data:geometry:flap_type"],
@@ -125,7 +125,7 @@ class ComputeDeltaHighLift(FigureDigitization):
                     flap_angle,
                     mach_ls,
                 )
-                x_cp_c_prime = self.x_cp_c_prime(flap_chord_ratio)
+                x_cp_c_prime = self.x_cp_c_prime(float(flap_chord_ratio))
                 outputs["data:aerodynamics:flaps:takeoff:CM_2D"] = cl_2d * (0.25 - x_cp_c_prime)
                 cd_3d = self._get_flaps_delta_cd(
                     inputs["data:geometry:flap_type"],
@@ -258,6 +258,7 @@ class ComputeDeltaHighLift(FigureDigitization):
         return delta_cm_flap
 
     @staticmethod
+    @functools.lru_cache(maxsize=256)
     def _get_flaps_delta_cd(
         flap_type, chord_ratio, thickness_ratio, flap_angle: float, area_ratio
     ) -> float:

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -258,7 +258,6 @@ class ComputeDeltaHighLift(FigureDigitization):
         return delta_cm_flap
 
     @staticmethod
-    @functools.lru_cache(maxsize=256)
     def _get_flaps_delta_cd(
         flap_type, chord_ratio, thickness_ratio, flap_angle: float, area_ratio
     ) -> float:

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -11,7 +11,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import functools
+
 from typing import Union, Tuple
 
 import numpy as np

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -217,11 +217,11 @@ class ComputeDeltaHighLift(FigureDigitization):
         y1_wing = inputs["data:geometry:fuselage:maximum_width"] / 2.0
         y2_wing = inputs["data:geometry:wing:root:y"]
         flap_span_ratio = inputs["data:geometry:flap:span_ratio"]
-        taper_ratio_wing = float(inputs["data:geometry:wing:taper_ratio"])
-        aspect_ratio_wing = float(inputs["data:geometry:wing:aspect_ratio"])
+        taper_ratio_wing = inputs["data:geometry:wing:taper_ratio"]
+        aspect_ratio_wing = inputs["data:geometry:wing:aspect_ratio"]
         flap_chord_ratio = inputs["data:geometry:flap:chord_ratio"]
-        wing_thickness_ratio = float(inputs["data:geometry:wing:thickness_ratio"])
-        sweep_25 = float(inputs["data:geometry:wing:sweep_25"]) * np.pi / 180.0
+        wing_thickness_ratio = inputs["data:geometry:wing:thickness_ratio"]
+        sweep_25 = inputs["data:geometry:wing:sweep_25"] * np.pi / 180.0
 
         beta_ref = np.sqrt(1.0 - mach ** 2.0)
         k = cl_alpha_airfoil_wing / (2.0 * np.pi)
@@ -241,15 +241,14 @@ class ComputeDeltaHighLift(FigureDigitization):
         )
 
         # Now we can compute the coefficient
-        eta_in = float(y1_wing / (span_wing / 2.0))
-        eta_out = float(
-            ((y2_wing - y1_wing) + flap_span_ratio * (span_wing / 2.0 - y2_wing))
-            / (span_wing / 2.0 - y2_wing)
+        eta_in = y1_wing / (span_wing / 2.0)
+        eta_out = ((y2_wing - y1_wing) + flap_span_ratio * (span_wing / 2.0 - y2_wing)) / (
+            span_wing / 2.0 - y2_wing
         )
-        k_delta = self.k_delta_flaps(taper_ratio_wing, eta_in, eta_out)
-        k_p = self.k_p_flaps(taper_ratio_wing, eta_in, eta_out)
+        k_delta = self.k_delta_flaps(float(taper_ratio_wing), float(eta_in), float(eta_out))
+        k_p = self.k_p_flaps(float(taper_ratio_wing), float(eta_in), float(eta_out))
         delta_cm_delta_cl_ref = self.pitch_to_reference_lift(
-            wing_thickness_ratio, float(flap_chord_ratio)
+            float(wing_thickness_ratio), float(flap_chord_ratio)
         )
 
         delta_cm_flap = (

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -181,8 +181,9 @@ class ComputeDeltaHighLift(FigureDigitization):
         y1_wing = inputs["data:geometry:fuselage:maximum_width"] / 2.0
         y2_wing = inputs["data:geometry:wing:root:y"]
         flap_span_ratio = inputs["data:geometry:flap:span_ratio"]
+        flap_chord_ratio = inputs["data:geometry:flap:chord_ratio"]
         taper_ratio_wing = inputs["data:geometry:wing:taper_ratio"]
-        aspect_ratio_wing = float(inputs["data:geometry:wing:aspect_ratio"])
+        aspect_ratio_wing = inputs["data:geometry:wing:aspect_ratio"]
         cl_alpha_airfoil_wing = inputs["data:aerodynamics:wing:airfoil:CL_alpha"]
 
         # 2D flap lift coefficient
@@ -192,9 +193,9 @@ class ComputeDeltaHighLift(FigureDigitization):
         eta_out = ((y2_wing - y1_wing) + flap_span_ratio * (span_wing / 2.0 - y2_wing)) / (
             span_wing / 2.0 - y2_wing
         )
-        k_b = self.k_b_flaps(eta_in, eta_out, taper_ratio_wing)
-        a_delta_flap = self.a_delta_airfoil(float(inputs["data:geometry:flap:chord_ratio"]))
-        k_a_delta = self.k_a_delta(a_delta_flap, aspect_ratio_wing)
+        k_b = self.k_b_flaps(float(eta_in), float(eta_out), float(taper_ratio_wing))
+        a_delta_flap = self.a_delta_airfoil(float(flap_chord_ratio))
+        k_a_delta = self.k_a_delta(float(a_delta_flap), float(aspect_ratio_wing))
         delta_cl0_flaps = (
             k_b * delta_cl_airfoil * (cl_alpha_wing / cl_alpha_airfoil_wing) * k_a_delta
         )
@@ -218,7 +219,7 @@ class ComputeDeltaHighLift(FigureDigitization):
         flap_span_ratio = inputs["data:geometry:flap:span_ratio"]
         taper_ratio_wing = float(inputs["data:geometry:wing:taper_ratio"])
         aspect_ratio_wing = float(inputs["data:geometry:wing:aspect_ratio"])
-        flap_chord_ratio = float(inputs["data:geometry:flap:chord_ratio"])
+        flap_chord_ratio = inputs["data:geometry:flap:chord_ratio"]
         wing_thickness_ratio = float(inputs["data:geometry:wing:thickness_ratio"])
         sweep_25 = float(inputs["data:geometry:wing:sweep_25"]) * np.pi / 180.0
 
@@ -232,9 +233,9 @@ class ComputeDeltaHighLift(FigureDigitization):
         delta_cl_2d_ref = self._compute_delta_cl_airfoil_2d(inputs, flap_angle, mach)
         eta_in_ref = 0.0
         eta_out_ref = 1.0
-        kb_ref = self.k_b_flaps(eta_in_ref, eta_out_ref, taper_ratio_wing)
-        a_delta_flap_ref = self.a_delta_airfoil(float(inputs["data:geometry:flap:chord_ratio"]))
-        k_a_delta_ref = self.k_a_delta(a_delta_flap_ref, 6.0)
+        kb_ref = self.k_b_flaps(eta_in_ref, eta_out_ref, float(taper_ratio_wing))
+        a_delta_flap_ref = self.a_delta_airfoil(float(flap_chord_ratio))
+        k_a_delta_ref = self.k_a_delta(float(a_delta_flap_ref), 6.0)
         delta_cl_ref = (
             kb_ref * delta_cl_2d_ref * (cl_alpha_ref / cl_alpha_airfoil_wing) * k_a_delta_ref
         )
@@ -247,7 +248,9 @@ class ComputeDeltaHighLift(FigureDigitization):
         )
         k_delta = self.k_delta_flaps(taper_ratio_wing, eta_in, eta_out)
         k_p = self.k_p_flaps(taper_ratio_wing, eta_in, eta_out)
-        delta_cm_delta_cl_ref = self.pitch_to_reference_lift(wing_thickness_ratio, flap_chord_ratio)
+        delta_cm_delta_cl_ref = self.pitch_to_reference_lift(
+            wing_thickness_ratio, float(flap_chord_ratio)
+        )
 
         delta_cm_flap = (
             k_delta * aspect_ratio_wing / 1.5 * np.tan(sweep_25) + k_p * delta_cm_delta_cl_ref
@@ -429,10 +432,10 @@ class ComputeDeltaHighLift(FigureDigitization):
         sweep_25 = inputs["data:geometry:wing:sweep_25"] * np.pi / 180.0
         flap_area_ratio = self._compute_flap_area_ratio(inputs)
 
-        base_increment = self.base_max_lift_increment(el_aero * 100.0, flap_type)
-        flap_chord_factor = self.k1_max_lift(flap_chord_ratio * 100.0, flap_type)
-        flap_angle_factor = self.k2_max_lift(flap_angle, flap_type)
-        flap_motion_factor = self.k3_max_lift(flap_angle, flap_type)
+        base_increment = self.base_max_lift_increment(float(el_aero) * 100.0, float(flap_type))
+        flap_chord_factor = self.k1_max_lift(float(flap_chord_ratio) * 100.0, float(flap_type))
+        flap_angle_factor = self.k2_max_lift(float(flap_angle), float(flap_type))
+        flap_motion_factor = self.k3_max_lift(float(flap_angle), float(flap_type))
 
         k_planform = (1.0 - 0.08 * np.cos(sweep_25) ** 2.0) * np.cos(sweep_25) ** (3.0 / 4.0)
         delta_cl_max_flaps = (

--- a/src/fastga/models/aerodynamics/components/hinge_moments_elevator.py
+++ b/src/fastga/models/aerodynamics/components/hinge_moments_elevator.py
@@ -176,11 +176,11 @@ class Compute2DHingeMomentsTail(FigureDigitization):
 
         else:
             cl_delta_th = self.cl_delta_theory_plain_flap(
-                tail_thickness_ratio, elevator_chord_ratio
+                float(tail_thickness_ratio), float(elevator_chord_ratio)
             )
 
             k_cl_delta = self.k_cl_delta_plain_flap(
-                tail_thickness_ratio, cl_alpha_airfoil_ht, elevator_chord_ratio
+                float(tail_thickness_ratio), float(cl_alpha_airfoil_ht), float(elevator_chord_ratio)
             )
 
             ch_prime_prime_delta = ch_prime_delta + (
@@ -257,7 +257,7 @@ class Compute3DHingeMomentsTail(FigureDigitization):
 
         # We'll compute the elevator effectiveness factor in the worst case scenario, i.e,
         # with the highest deflection angle which we will take at 25 degree
-        a_delta = self.k_prime_single_slotted(elevator_angle, elevator_chord_ratio)
+        a_delta = self.k_prime_single_slotted(elevator_angle, float(elevator_chord_ratio))
 
         ch_delta_3d = (
             np.cos(sweep_25_ht)

--- a/src/fastga/models/aerodynamics/components/hinge_moments_elevator.py
+++ b/src/fastga/models/aerodynamics/components/hinge_moments_elevator.py
@@ -115,10 +115,10 @@ class Compute2DHingeMomentsTail(FigureDigitization):
         k_cl_alpha = float(cl_alpha_airfoil_ht) / float(cl_alpha_ht_th)
 
         k_ch_alpha = self.k_ch_alpha(
-            tail_thickness_ratio, cl_alpha_airfoil_ht, elevator_chord_ratio
+            float(tail_thickness_ratio), float(cl_alpha_airfoil_ht), float(elevator_chord_ratio)
         )
 
-        ch_alpha = self.ch_alpha_th(tail_thickness_ratio, elevator_chord_ratio)
+        ch_alpha = self.ch_alpha_th(float(tail_thickness_ratio), float(elevator_chord_ratio))
 
         ch_prime_alpha = k_ch_alpha * ch_alpha
 
@@ -162,10 +162,10 @@ class Compute2DHingeMomentsTail(FigureDigitization):
         # Step 2.
 
         k_ch_delta = self.k_ch_delta(
-            tail_thickness_ratio, cl_alpha_airfoil_ht, elevator_chord_ratio
+            float(tail_thickness_ratio), float(cl_alpha_airfoil_ht), float(elevator_chord_ratio)
         )
 
-        ch_delta = self.ch_delta_th(tail_thickness_ratio, elevator_chord_ratio)
+        ch_delta = self.ch_delta_th(float(tail_thickness_ratio), float(elevator_chord_ratio))
 
         ch_prime_delta = k_ch_delta * ch_delta
 


### PR DESCRIPTION
This PR closes #188 (partially)

The decorator has been added to all function that needs to read a .CSV file and that are used in the sizing process. The gain in time can be seen on the global OAD process. A couple of observations however:
- For a MDA, it may not be worth to add the decorator on some function that are used only once or twice in a loop, but for the MDO, as long as the inputs are not optimization variable the gain could be great
- The openvsp and vlm component could not be changed because the functions used the input vector directly which means that if we are to use that decorator, we would need to deeply changed the components