### PR TITLE
Dev partial derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ It is recommended (but not required) to install FAST-(OAD)-GA in a virtual
 environment ([conda](https://docs.conda.io/en/latest/),
 [venv](https://docs.python.org/3.7/library/venv.html), ...).
 
-The FAST-(OAD)-GA is not registered for a direct pip install.
-Yet an installation using pip command is possible. To do so, use command:
-**pip install fast-oad-cs23==xxx**, where xxx is the version number (ex: 1.0.0).
+Once Python is installed, FAST-(OAD)-GA can be installed using pip, by doing the following:
+
+``` {.bash}
+$ pip install fast-oad-cs23
+```

--- a/integration_tests/oad_process/data/oad_process_be76.yml
+++ b/integration_tests/oad_process/data/oad_process_be76.yml
@@ -35,8 +35,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         performance:
             id: fastga.performances.mission
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -46,6 +44,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/data/oad_process_be76_mission_builder.yml
+++ b/integration_tests/oad_process/data/oad_process_be76_mission_builder.yml
@@ -34,8 +34,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         pre_mission_builder:
             id: fastga.performances.mission_builder_prep
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -55,6 +53,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/data/oad_process_sr22.yml
+++ b/integration_tests/oad_process/data/oad_process_sr22.yml
@@ -34,8 +34,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         performance:
             id: fastga.performances.mission
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -46,6 +44,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/data/oad_process_sr22_mission_builder.yml
+++ b/integration_tests/oad_process/data/oad_process_sr22_mission_builder.yml
@@ -32,8 +32,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         pre_mission_builder:
             id: fastga.performances.mission_builder_prep
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -53,6 +51,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/data/oad_process_sr22_mission_vector.yml
+++ b/integration_tests/oad_process/data/oad_process_sr22_mission_vector.yml
@@ -34,8 +34,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         performance:
             id: fastga.performances.mission_vector
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -45,6 +43,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/data/oad_process_sr22_openvsp.yml
+++ b/integration_tests/oad_process/data/oad_process_sr22_openvsp.yml
@@ -34,8 +34,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         performance:
             id: fastga.performances.mission
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -46,6 +44,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/data/oad_process_tbm900.yml
+++ b/integration_tests/oad_process/data/oad_process_tbm900.yml
@@ -42,8 +42,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicTurbopropMapped
-        mtow:
-            id: fastga.loop.mtow
         performance:
             id: fastga.performances.mission
             propulsion_id: fastga.wrapper.propulsion.basicTurbopropMapped
@@ -54,6 +52,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicTurbopropMapped
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/integration_tests/oad_process/test_oad_process.py
+++ b/integration_tests/oad_process/test_oad_process.py
@@ -77,7 +77,7 @@ def test_oad_process_vlm_sr22(cleanup):
     assert_allclose(problem.get_val("data:mission:sizing:fuel", units="kg"), 252.0, atol=1)
     assert_allclose(problem["data:handling_qualities:stick_fixed_static_margin"], 0.15, atol=1e-2)
     # noinspection PyTypeChecker
-    assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 1654.0, atol=1)
+    assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 1655.0, atol=1)
     # noinspection PyTypeChecker
     assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 1027.0, atol=1)
 
@@ -157,9 +157,9 @@ def test_oad_process_tbm_900(cleanup):
     assert_allclose(problem.get_val("data:mission:sizing:fuel", units="kg"), 766.0, atol=1)
     assert_allclose(problem["data:handling_qualities:stick_fixed_static_margin"], 0.22, atol=1e-2)
     # noinspection PyTypeChecker
-    assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 3361.0, atol=1)
+    assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 3358.0, atol=1)
     # noinspection PyTypeChecker
-    assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 2115.0, atol=1)
+    assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 2112.0, atol=1)
 
 
 def test_oad_process_vlm_mission_vector(cleanup):
@@ -244,7 +244,7 @@ def test_oad_process_openvsp(cleanup):
     # noinspection PyTypeChecker
     assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 1651.0, atol=1)
     # noinspection PyTypeChecker
-    assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 1027.0, atol=1)
+    assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 1028.0, atol=1)
 
 
 def test_oad_process_mission_builder_1_engine(cleanup):
@@ -346,9 +346,9 @@ def test_oad_process_mission_builder_2_engine(cleanup):
     assert_allclose(problem.get_val("data:mission:sizing:fuel", units="kg"), 250.0, atol=1)
     assert_allclose(problem["data:handling_qualities:stick_fixed_static_margin"], 0.25, atol=1e-2)
     # noinspection PyTypeChecker
-    assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 1735.0, atol=1)
+    assert_allclose(problem.get_val("data:weight:aircraft:MTOW", units="kg"), 1736.0, atol=1)
     # noinspection PyTypeChecker
-    assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 1104.0, atol=1)
+    assert_allclose(problem.get_val("data:weight:aircraft:OWE", units="kg"), 1105.0, atol=1)
 
 
 def _check_weight_performance_loop(problem):

--- a/src/fastga/configurations/fastga.yml
+++ b/src/fastga/configurations/fastga.yml
@@ -36,8 +36,6 @@ model:
         weight:
             id: fastga.weight.legacy
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
-        mtow:
-            id: fastga.loop.mtow
         performance:
             id: fastga.performances.mission
             propulsion_id: fastga.wrapper.propulsion.basicIC_engine
@@ -48,6 +46,8 @@ model:
                 propulsion_id: fastga.wrapper.propulsion.basicIC_engine
             static_margin:
                 id: fastga.handling_qualities.static_margin
+        mtow:
+            id: fastga.loop.mtow
         wing_position:
             id: fastga.loop.wing_position
         wing_area:

--- a/src/fastga/models/aerodynamics/components/cd0_fuselage.py
+++ b/src/fastga/models/aerodynamics/components/cd0_fuselage.py
@@ -40,10 +40,18 @@ class Cd0Fuselage(ExplicitComponent):
         self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")
         if self.options["low_speed_aero"]:
             self.add_input("data:aerodynamics:low_speed:unit_reynolds", val=np.nan, units="m**-1")
-            self.add_output("data:aerodynamics:fuselage:low_speed:CD0")
+            self.add_output("data:aerodynamics:fuselage:low_speed:CD0", val=0.025)
+
+            self.declare_partials(
+                of="data:aerodynamics:fuselage:low_speed:CD0", wrt="*", method="exact"
+            )
         else:
             self.add_input("data:aerodynamics:cruise:unit_reynolds", val=np.nan, units="m**-1")
-            self.add_output("data:aerodynamics:fuselage:cruise:CD0")
+            self.add_output("data:aerodynamics:fuselage:cruise:CD0", val=0.025)
+
+            self.declare_partials(
+                of="data:aerodynamics:fuselage:cruise:CD0", wrt="*", method="exact"
+            )
 
         self.declare_partials("*", "*", method="fd")
 
@@ -64,8 +72,8 @@ class Cd0Fuselage(ExplicitComponent):
         # 5% NLF
         x_trans = 0.05
         # Roots
-        x0_turbulent = 36.9 * x_trans ** 0.625 * (1.0 / reynolds) ** 0.375
-        cf_fus = 0.074 / reynolds ** 0.2 * (1.0 - (x_trans - x0_turbulent)) ** 0.8
+        x0_turbulent = 36.9 * x_trans ** 0.625 * reynolds ** -0.375
+        cf_fus = 0.074 * reynolds ** -0.2 * (1.0 - (x_trans - x0_turbulent)) ** 0.8
         fineness_ratio = length / np.sqrt(4 * height * width / np.pi)
         form_factor_fus = 1.0 + 60.0 / (fineness_ratio ** 3.0) + fineness_ratio / 400.0
         # Fuselage
@@ -77,3 +85,115 @@ class Cd0Fuselage(ExplicitComponent):
             outputs["data:aerodynamics:fuselage:low_speed:CD0"] = cd0_fuselage + cd0_window
         else:
             outputs["data:aerodynamics:fuselage:cruise:CD0"] = cd0_fuselage + cd0_window
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        height = inputs["data:geometry:fuselage:maximum_height"]
+        width = inputs["data:geometry:fuselage:maximum_width"]
+        length = inputs["data:geometry:fuselage:length"]
+        wet_area_fus = inputs["data:geometry:fuselage:wet_area"]
+        wing_area = inputs["data:geometry:wing:area"]
+
+        if self.options["low_speed_aero"]:
+            unit_reynolds = inputs["data:aerodynamics:low_speed:unit_reynolds"]
+        else:
+            unit_reynolds = inputs["data:aerodynamics:cruise:unit_reynolds"]
+
+        d_cd0_w_d_height = 0.002 * width / wing_area
+        d_cd0_w_d_width = 0.002 * height / wing_area
+        d_cd0_w_d_area = -0.002 * width * height / wing_area ** 2.0
+
+        # Local Reynolds:
+        reynolds = unit_reynolds * length
+        x_trans = 0.05
+        x0_turbulent = 36.9 * x_trans ** 0.625 * reynolds ** -0.375
+
+        d_x0_turb_d_unit_re = (
+            -0.375 * 36.9 * x_trans ** 0.625 * length ** -0.375 * unit_reynolds ** -1.375
+        )
+        d_x0_turb_d_length = (
+            -0.375 * 36.9 * x_trans ** 0.625 * unit_reynolds ** -0.375 * length ** -1.375
+        )
+
+        cf_fus = 0.074 * reynolds ** -0.2 * (1.0 - (x_trans - x0_turbulent)) ** 0.8
+        d_cf_fus_d_unit_re = (
+            -0.2
+            * 0.074
+            * length ** -0.2
+            * unit_reynolds ** -1.2
+            * (1.0 - (x_trans - x0_turbulent)) ** 0.8
+        ) + 0.074 * reynolds ** -0.2 * 0.8 * (
+            1.0 - (x_trans - x0_turbulent)
+        ) ** -0.2 * d_x0_turb_d_unit_re
+        d_cf_fus_d_length = (
+            -0.2
+            * 0.074
+            * unit_reynolds ** -0.2
+            * length ** -1.2
+            * (1.0 - (x_trans - x0_turbulent)) ** 0.8
+        ) + 0.074 * reynolds ** -0.2 * 0.8 * (
+            1.0 - (x_trans - x0_turbulent)
+        ) ** -0.2 * d_x0_turb_d_length
+
+        fineness_ratio = length / np.sqrt(4 * height * width / np.pi)
+        d_f_d_length = 1.0 / np.sqrt(4 * height * width / np.pi)
+        d_f_d_height = -0.5 * length / np.sqrt(4 * width / np.pi) * height ** -1.5
+        d_f_d_width = -0.5 * length / np.sqrt(4 * height / np.pi) * width ** -1.5
+
+        form_factor_fus = 1.0 + 60.0 / (fineness_ratio ** 3.0) + fineness_ratio / 400.0
+        d_ff_d_f = -3.0 * 60 * fineness_ratio ** -4.0 + 1.0 / 400.0
+        d_ff_d_length = d_ff_d_f * d_f_d_length
+        d_ff_d_height = d_ff_d_f * d_f_d_height
+        d_ff_d_width = d_ff_d_f * d_f_d_width
+
+        d_cd0_fus_d_length = (
+            wet_area_fus
+            / wing_area
+            * (d_cf_fus_d_length * form_factor_fus + d_ff_d_length * cf_fus)
+        )
+        d_cd0_fus_d_height = cf_fus * wet_area_fus / wing_area * d_ff_d_height
+        d_cd0_fus_d_width = cf_fus * wet_area_fus / wing_area * d_ff_d_width
+        d_cd0_fus_d_unit_re = form_factor_fus * wet_area_fus / wing_area * d_cf_fus_d_unit_re
+        d_cd0_fus_d_wet_area = form_factor_fus * cf_fus / wing_area
+        d_cd0_fus_d_area = -form_factor_fus * cf_fus * wet_area_fus / wing_area ** 2.0
+
+        if self.options["low_speed_aero"]:
+            partials[
+                "data:aerodynamics:fuselage:low_speed:CD0", "data:geometry:fuselage:maximum_height"
+            ] = (d_cd0_fus_d_height + d_cd0_w_d_height)
+            partials[
+                "data:aerodynamics:fuselage:low_speed:CD0", "data:geometry:fuselage:maximum_width"
+            ] = (d_cd0_fus_d_width + d_cd0_w_d_width)
+            partials[
+                "data:aerodynamics:fuselage:low_speed:CD0", "data:geometry:fuselage:length"
+            ] = d_cd0_fus_d_length
+            partials[
+                "data:aerodynamics:fuselage:low_speed:CD0", "data:geometry:fuselage:wet_area"
+            ] = d_cd0_fus_d_wet_area
+            partials["data:aerodynamics:fuselage:low_speed:CD0", "data:geometry:wing:area"] = (
+                d_cd0_fus_d_area + d_cd0_w_d_area
+            )
+            partials[
+                "data:aerodynamics:fuselage:low_speed:CD0",
+                "data:aerodynamics:low_speed:unit_reynolds",
+            ] = d_cd0_fus_d_unit_re
+        else:
+            partials[
+                "data:aerodynamics:fuselage:cruise:CD0", "data:geometry:fuselage:maximum_height"
+            ] = (d_cd0_fus_d_height + d_cd0_w_d_height)
+            partials[
+                "data:aerodynamics:fuselage:cruise:CD0", "data:geometry:fuselage:maximum_width"
+            ] = (d_cd0_fus_d_width + d_cd0_w_d_width)
+            partials[
+                "data:aerodynamics:fuselage:cruise:CD0", "data:geometry:fuselage:length"
+            ] = d_cd0_fus_d_length
+            partials[
+                "data:aerodynamics:fuselage:cruise:CD0", "data:geometry:fuselage:wet_area"
+            ] = d_cd0_fus_d_wet_area
+            partials["data:aerodynamics:fuselage:cruise:CD0", "data:geometry:wing:area"] = (
+                d_cd0_fus_d_area + d_cd0_w_d_area
+            )
+            partials[
+                "data:aerodynamics:fuselage:cruise:CD0",
+                "data:aerodynamics:cruise:unit_reynolds",
+            ] = d_cd0_fus_d_unit_re

--- a/src/fastga/models/aerodynamics/components/cd0_total.py
+++ b/src/fastga/models/aerodynamics/components/cd0_total.py
@@ -51,6 +51,8 @@ class Cd0Total(ExplicitComponent):
             self.add_input("data:aerodynamics:landing_gear:low_speed:CD0", val=np.nan)
             self.add_input("data:aerodynamics:other:low_speed:CD0", val=np.nan)
             self.add_output("data:aerodynamics:aircraft:low_speed:CD0")
+
+            self.declare_partials("*", "*", method="exact")
         else:
             self.add_input("data:aerodynamics:wing:cruise:CD0", val=np.nan)
             self.add_input("data:aerodynamics:fuselage:cruise:CD0", val=np.nan)
@@ -61,7 +63,7 @@ class Cd0Total(ExplicitComponent):
             self.add_input("data:aerodynamics:other:cruise:CD0", val=np.nan)
             self.add_output("data:aerodynamics:aircraft:cruise:CD0")
 
-        self.declare_partials("*", "*", method="fd")
+            self.declare_partials("*", "*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 
@@ -91,3 +93,85 @@ class Cd0Total(ExplicitComponent):
             outputs["data:aerodynamics:aircraft:low_speed:CD0"] = cd0
         else:
             outputs["data:aerodynamics:aircraft:cruise:CD0"] = cd0
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        crud_factor = inputs["settings:aerodynamics:aircraft:undesirable_drag:k_factor"]
+
+        if self.options["low_speed_aero"]:
+            cd0_wing = inputs["data:aerodynamics:wing:low_speed:CD0"]
+            cd0_fus = inputs["data:aerodynamics:fuselage:low_speed:CD0"]
+            cd0_ht = inputs["data:aerodynamics:horizontal_tail:low_speed:CD0"]
+            cd0_vt = inputs["data:aerodynamics:vertical_tail:low_speed:CD0"]
+            cd0_nac = inputs["data:aerodynamics:nacelles:low_speed:CD0"]
+            cd0_lg = inputs["data:aerodynamics:landing_gear:low_speed:CD0"]
+            cd0_other = inputs["data:aerodynamics:other:low_speed:CD0"]
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0", "data:aerodynamics:wing:low_speed:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0",
+                "data:aerodynamics:fuselage:low_speed:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0",
+                "data:aerodynamics:horizontal_tail:low_speed:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0",
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0",
+                "data:aerodynamics:nacelles:low_speed:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0",
+                "data:aerodynamics:landing_gear:low_speed:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0", "data:aerodynamics:other:low_speed:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:low_speed:CD0",
+                "settings:aerodynamics:aircraft:undesirable_drag:k_factor",
+            ] = (
+                cd0_wing + cd0_fus + cd0_ht + cd0_vt + cd0_lg + cd0_nac + cd0_other
+            )
+        else:
+            cd0_wing = inputs["data:aerodynamics:wing:cruise:CD0"]
+            cd0_fus = inputs["data:aerodynamics:fuselage:cruise:CD0"]
+            cd0_ht = inputs["data:aerodynamics:horizontal_tail:cruise:CD0"]
+            cd0_vt = inputs["data:aerodynamics:vertical_tail:cruise:CD0"]
+            cd0_nac = inputs["data:aerodynamics:nacelles:cruise:CD0"]
+            cd0_lg = inputs["data:aerodynamics:landing_gear:cruise:CD0"]
+            cd0_other = inputs["data:aerodynamics:other:cruise:CD0"]
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0", "data:aerodynamics:wing:cruise:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0", "data:aerodynamics:fuselage:cruise:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0",
+                "data:aerodynamics:horizontal_tail:cruise:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0",
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0", "data:aerodynamics:nacelles:cruise:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0", "data:aerodynamics:landing_gear:cruise:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0", "data:aerodynamics:other:cruise:CD0"
+            ] = crud_factor
+            partials[
+                "data:aerodynamics:aircraft:cruise:CD0",
+                "settings:aerodynamics:aircraft:undesirable_drag:k_factor",
+            ] = (
+                cd0_wing + cd0_fus + cd0_ht + cd0_vt + cd0_lg + cd0_nac + cd0_other
+            )

--- a/src/fastga/models/aerodynamics/components/cd0_total.py
+++ b/src/fastga/models/aerodynamics/components/cd0_total.py
@@ -35,6 +35,13 @@ class Cd0Total(ExplicitComponent):
 
     def setup(self):
 
+        self.add_input(
+            "settings:aerodynamics:aircraft:undesirable_drag:k_factor",
+            val=1.25,
+            desc="Correction coefficient to take into account the other undesirable drag, "
+            "default is 1.25 as suggested in Gudmundsson",
+        )
+
         if self.options["low_speed_aero"]:
             self.add_input("data:aerodynamics:wing:low_speed:CD0", val=np.nan)
             self.add_input("data:aerodynamics:fuselage:low_speed:CD0", val=np.nan)
@@ -76,7 +83,7 @@ class Cd0Total(ExplicitComponent):
             cd0_other = inputs["data:aerodynamics:other:cruise:CD0"]
 
         # CRUD (other undesirable drag). Factor from Gudmundsson book
-        crud_factor = 1.25
+        crud_factor = inputs["settings:aerodynamics:aircraft:undesirable_drag:k_factor"]
 
         cd0 = crud_factor * (cd0_wing + cd0_fus + cd0_ht + cd0_vt + cd0_lg + cd0_nac + cd0_other)
 

--- a/src/fastga/models/aerodynamics/components/cd0_vt.py
+++ b/src/fastga/models/aerodynamics/components/cd0_vt.py
@@ -38,21 +38,26 @@ class Cd0VerticalTail(ExplicitComponent):
 
         self.add_input("data:geometry:vertical_tail:tip:chord", val=np.nan, units="m")
         self.add_input("data:geometry:vertical_tail:root:chord", val=np.nan, units="m")
-        self.add_input("data:geometry:vertical_tail:sweep_25", val=np.nan, units="deg")
+        self.add_input("data:geometry:vertical_tail:sweep_25", val=np.nan, units="rad")
         self.add_input("data:geometry:vertical_tail:wet_area", val=np.nan, units="m**2")
         self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")
         self.add_input("data:geometry:vertical_tail:thickness_ratio", val=np.nan)
         self.add_input("data:geometry:vertical_tail:max_thickness:x_ratio", val=0.3)
+
         if self.options["low_speed_aero"]:
             self.add_input("data:aerodynamics:low_speed:mach", val=np.nan)
             self.add_input("data:aerodynamics:low_speed:unit_reynolds", val=np.nan, units="m**-1")
+
             self.add_output("data:aerodynamics:vertical_tail:low_speed:CD0")
+
+            self.declare_partials("*", "*", method="exact")
         else:
             self.add_input("data:aerodynamics:cruise:mach", val=np.nan)
             self.add_input("data:aerodynamics:cruise:unit_reynolds", val=np.nan, units="m**-1")
+
             self.add_output("data:aerodynamics:vertical_tail:cruise:CD0")
 
-        self.declare_partials("*", "*", method="fd")
+            self.declare_partials("*", "*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 
@@ -85,9 +90,7 @@ class Cd0VerticalTail(ExplicitComponent):
         form_factor = 1 + 0.6 / x_t_max * thickness + 100 * thickness ** 4
         form_factor = form_factor * 1.05  # Due to hinged elevator (Raymer)
         if mach > 0.2:
-            form_factor = (
-                form_factor * 1.34 * mach ** 0.18 * (np.cos(sweep_25_vt * np.pi / 180)) ** 0.28
-            )
+            form_factor = form_factor * 1.34 * mach ** 0.18 * (np.cos(sweep_25_vt)) ** 0.28
         interference_factor = 1.05
         cd0 = form_factor * interference_factor * cf_vt * wet_area_vt / wing_area
 
@@ -95,3 +98,297 @@ class Cd0VerticalTail(ExplicitComponent):
             outputs["data:aerodynamics:vertical_tail:low_speed:CD0"] = cd0
         else:
             outputs["data:aerodynamics:vertical_tail:cruise:CD0"] = cd0
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        tip_chord = inputs["data:geometry:vertical_tail:tip:chord"]
+        root_chord = inputs["data:geometry:vertical_tail:root:chord"]
+        sweep_25_vt = inputs["data:geometry:vertical_tail:sweep_25"]
+        wet_area_vt = inputs["data:geometry:vertical_tail:wet_area"]
+        wing_area = inputs["data:geometry:wing:area"]
+        thickness = inputs["data:geometry:vertical_tail:thickness_ratio"]
+        x_t_max = inputs["data:geometry:vertical_tail:max_thickness:x_ratio"]
+
+        if self.options["low_speed_aero"]:
+            mach = inputs["data:aerodynamics:low_speed:mach"]
+            unit_reynolds = inputs["data:aerodynamics:low_speed:unit_reynolds"]
+
+        else:
+            mach = inputs["data:aerodynamics:cruise:mach"]
+            unit_reynolds = inputs["data:aerodynamics:cruise:unit_reynolds"]
+
+        x_trans = 0.5
+
+        # Tip
+        reynolds_tip = unit_reynolds * tip_chord
+        x0_tip = 36.9 * x_trans ** 0.625 * reynolds_tip ** -0.375
+
+        d_x0_tip_d_unit_re = (
+            -0.375 * 36.9 * x_trans ** 0.625 * tip_chord ** -0.375 * unit_reynolds ** -1.375
+        )
+        d_x0_tip_d_tip_chord = (
+            -0.375 * 36.9 * x_trans ** 0.625 * unit_reynolds ** -0.375 * tip_chord ** -1.375
+        )
+
+        cf_vt_tip = 0.074 * reynolds_tip ** -0.2 * (1.0 - (x_trans - x0_tip)) ** 0.8
+
+        d_cf_vt_tip_d_unit_re = (
+            -0.2
+            * 0.074
+            * tip_chord ** -0.2
+            * unit_reynolds ** -1.2
+            * (1.0 - (x_trans - x0_tip)) ** 0.8
+        ) + 0.074 * reynolds_tip ** -0.2 * 0.8 * (
+            1.0 - (x_trans - x0_tip)
+        ) ** -0.2 * d_x0_tip_d_unit_re
+        d_cf_vt_tip_d_chord_tip = (
+            -0.2
+            * 0.074
+            * unit_reynolds ** -0.2
+            * tip_chord ** -1.2
+            * (1.0 - (x_trans - x0_tip)) ** 0.8
+        ) + 0.074 * reynolds_tip ** -0.2 * 0.8 * (
+            1.0 - (x_trans - x0_tip)
+        ) ** -0.2 * d_x0_tip_d_tip_chord
+
+        # Root
+        reynolds_root = unit_reynolds * root_chord
+        x_trans = 0.5
+        x0_root = 36.9 * x_trans ** 0.625 * reynolds_root ** -0.375
+
+        d_x0_root_d_unit_re = (
+            -0.375 * 36.9 * x_trans ** 0.625 * root_chord ** -0.375 * unit_reynolds ** -1.375
+        )
+        d_x0_root_d_root_chord = (
+            -0.375 * 36.9 * x_trans ** 0.625 * unit_reynolds ** -0.375 * root_chord ** -1.375
+        )
+
+        cf_vt_root = 0.074 * reynolds_root ** -0.2 * (1.0 - (x_trans - x0_root)) ** 0.8
+
+        d_cf_vt_root_d_unit_re = (
+            -0.2
+            * 0.074
+            * root_chord ** -0.2
+            * unit_reynolds ** -1.2
+            * (1.0 - (x_trans - x0_root)) ** 0.8
+        ) + 0.074 * reynolds_root ** -0.2 * 0.8 * (
+            1.0 - (x_trans - x0_root)
+        ) ** -0.2 * d_x0_root_d_unit_re
+        d_cf_vt_root_d_chord_root = (
+            -0.2
+            * 0.074
+            * unit_reynolds ** -0.2
+            * root_chord ** -1.2
+            * (1.0 - (x_trans - x0_root)) ** 0.8
+        ) + 0.074 * reynolds_root ** -0.2 * 0.8 * (
+            1.0 - (x_trans - x0_root)
+        ) ** -0.2 * d_x0_root_d_root_chord
+
+        cf_vt = (cf_vt_root + cf_vt_tip) * 0.5
+        d_cf_vt_d_unit_re = 0.5 * (d_cf_vt_root_d_unit_re + d_cf_vt_tip_d_unit_re)
+        d_cf_vt_d_chord_tip = 0.5 * d_cf_vt_tip_d_chord_tip
+        c_cf_vt_d_chord_root = 0.5 * d_cf_vt_root_d_chord_root
+
+        form_factor = 1.05 * (1 + 0.6 / x_t_max * thickness + 100 * thickness ** 4.0)
+
+        d_ff_d_location = -1.05 * 0.6 / x_t_max ** 2.0 * thickness
+        d_ff_d_thickness = 1.05 * (0.6 / x_t_max + 4.0 * 100 * thickness ** 3.0)
+
+        if mach > 0.2:
+            mach_correction = 1.34 * mach ** 0.18 * (np.cos(sweep_25_vt)) ** 0.28
+            d_mach_correction_d_mach = 0.18 * 1.34 * mach ** -0.82 * (np.cos(sweep_25_vt)) ** 0.28
+            d_mach_correction_d_sweep = (
+                -0.28 * 1.34 * mach ** 0.18 * (np.cos(sweep_25_vt)) ** -0.72 * np.sin(sweep_25_vt)
+            )
+        else:
+            mach_correction = 1.0
+            d_mach_correction_d_mach = 0.0
+            d_mach_correction_d_sweep = 0.0
+
+        interference_factor = 1.05
+
+        if self.options["low_speed_aero"]:
+
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:geometry:vertical_tail:tip:chord",
+            ] = (
+                form_factor
+                * mach_correction
+                * interference_factor
+                * d_cf_vt_d_chord_tip
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:geometry:vertical_tail:root:chord",
+            ] = (
+                form_factor
+                * mach_correction
+                * interference_factor
+                * c_cf_vt_d_chord_root
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:geometry:vertical_tail:sweep_25",
+            ] = (
+                form_factor
+                * d_mach_correction_d_sweep
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:geometry:vertical_tail:wet_area",
+            ] = (
+                form_factor * mach_correction * interference_factor * cf_vt / wing_area
+            )
+            partials["data:aerodynamics:vertical_tail:low_speed:CD0", "data:geometry:wing:area"] = (
+                -form_factor
+                * mach_correction
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area ** 2.0
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:geometry:vertical_tail:thickness_ratio",
+            ] = (
+                d_ff_d_thickness
+                * mach_correction
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:geometry:vertical_tail:max_thickness:x_ratio",
+            ] = (
+                d_ff_d_location
+                * mach_correction
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0", "data:aerodynamics:low_speed:mach"
+            ] = (
+                form_factor
+                * d_mach_correction_d_mach
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:low_speed:CD0",
+                "data:aerodynamics:low_speed:unit_reynolds",
+            ] = (
+                form_factor
+                * mach_correction
+                * interference_factor
+                * d_cf_vt_d_unit_re
+                * wet_area_vt
+                / wing_area
+            )
+
+        else:
+
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:geometry:vertical_tail:tip:chord",
+            ] = (
+                form_factor
+                * mach_correction
+                * interference_factor
+                * d_cf_vt_d_chord_tip
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:geometry:vertical_tail:root:chord",
+            ] = (
+                form_factor
+                * mach_correction
+                * interference_factor
+                * c_cf_vt_d_chord_root
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:geometry:vertical_tail:sweep_25",
+            ] = (
+                form_factor
+                * d_mach_correction_d_sweep
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:geometry:vertical_tail:wet_area",
+            ] = (
+                form_factor * mach_correction * interference_factor * cf_vt / wing_area
+            )
+            partials["data:aerodynamics:vertical_tail:cruise:CD0", "data:geometry:wing:area"] = (
+                -form_factor
+                * mach_correction
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area ** 2.0
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:geometry:vertical_tail:thickness_ratio",
+            ] = (
+                d_ff_d_thickness
+                * mach_correction
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:geometry:vertical_tail:max_thickness:x_ratio",
+            ] = (
+                d_ff_d_location
+                * mach_correction
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0", "data:aerodynamics:cruise:mach"
+            ] = (
+                form_factor
+                * d_mach_correction_d_mach
+                * interference_factor
+                * cf_vt
+                * wet_area_vt
+                / wing_area
+            )
+            partials[
+                "data:aerodynamics:vertical_tail:cruise:CD0",
+                "data:aerodynamics:cruise:unit_reynolds",
+            ] = (
+                form_factor
+                * mach_correction
+                * interference_factor
+                * d_cf_vt_d_unit_re
+                * wet_area_vt
+                / wing_area
+            )

--- a/src/fastga/models/aerodynamics/components/compute_L_D_max.py
+++ b/src/fastga/models/aerodynamics/components/compute_L_D_max.py
@@ -38,7 +38,39 @@ class ComputeLDMax(ExplicitComponent):
         self.add_output("data:aerodynamics:aircraft:cruise:optimal_CD")
         self.add_output("data:aerodynamics:aircraft:cruise:optimal_alpha", units="deg")
 
-        self.declare_partials("*", "*", method="fd")
+        self.declare_partials(
+            "data:aerodynamics:aircraft:cruise:optimal_CL",
+            [
+                "data:aerodynamics:aircraft:cruise:CD0",
+                "data:aerodynamics:wing:cruise:induced_drag_coefficient",
+            ],
+            method="exact",
+        )
+        self.declare_partials(
+            "data:aerodynamics:aircraft:cruise:optimal_CD",
+            [
+                "data:aerodynamics:aircraft:cruise:CD0",
+            ],
+            method="exact",
+        )
+        self.declare_partials(
+            "data:aerodynamics:aircraft:cruise:L_D_max",
+            [
+                "data:aerodynamics:aircraft:cruise:CD0",
+                "data:aerodynamics:wing:cruise:induced_drag_coefficient",
+            ],
+            method="exact",
+        )
+        self.declare_partials(
+            "data:aerodynamics:aircraft:cruise:optimal_alpha",
+            [
+                "data:aerodynamics:aircraft:cruise:CD0",
+                "data:aerodynamics:wing:cruise:induced_drag_coefficient",
+                "data:aerodynamics:wing:cruise:CL_alpha",
+                "data:aerodynamics:wing:cruise:CL0_clean",
+            ],
+            method="exact",
+        )
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 
@@ -56,3 +88,61 @@ class ComputeLDMax(ExplicitComponent):
         outputs["data:aerodynamics:aircraft:cruise:optimal_CL"] = cl_opt
         outputs["data:aerodynamics:aircraft:cruise:optimal_CD"] = cd_opt
         outputs["data:aerodynamics:aircraft:cruise:optimal_alpha"] = alpha_opt
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        cl0_clean = inputs["data:aerodynamics:wing:cruise:CL0_clean"]
+        cl_alpha = inputs["data:aerodynamics:wing:cruise:CL_alpha"]
+        cd0 = inputs["data:aerodynamics:aircraft:cruise:CD0"]
+        coeff_k = inputs["data:aerodynamics:wing:cruise:induced_drag_coefficient"]
+
+        cl_opt = np.sqrt(cd0 / coeff_k)
+        d_cl_opt_d_cd0 = 0.5 * np.sqrt(1.0 / (coeff_k * cd0))
+        d_cl_opt_d_coeff_k = -0.5 * np.sqrt(cd0) * coeff_k ** -1.5
+
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_CL", "data:aerodynamics:aircraft:cruise:CD0"
+        ] = d_cl_opt_d_cd0
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_CL",
+            "data:aerodynamics:wing:cruise:induced_drag_coefficient",
+        ] = d_cl_opt_d_coeff_k
+
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_CD", "data:aerodynamics:aircraft:cruise:CD0"
+        ] = 2.0
+
+        partials[
+            "data:aerodynamics:aircraft:cruise:L_D_max", "data:aerodynamics:aircraft:cruise:CD0"
+        ] = (-0.25 * coeff_k ** -0.5 * cd0 ** -1.5)
+        partials[
+            "data:aerodynamics:aircraft:cruise:L_D_max",
+            "data:aerodynamics:wing:cruise:induced_drag_coefficient",
+        ] = (
+            -0.25 * coeff_k ** -1.5 * cd0 ** -0.5
+        )
+
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_alpha",
+            "data:aerodynamics:aircraft:cruise:CD0",
+        ] = (
+            d_cl_opt_d_cd0 / cl_alpha * 180 / np.pi
+        )
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_alpha",
+            "data:aerodynamics:wing:cruise:induced_drag_coefficient",
+        ] = (
+            d_cl_opt_d_coeff_k / cl_alpha * 180 / np.pi
+        )
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_alpha",
+            "data:aerodynamics:wing:cruise:CL0_clean",
+        ] = (
+            -1.0 / cl_alpha * 180 / np.pi
+        )
+        partials[
+            "data:aerodynamics:aircraft:cruise:optimal_alpha",
+            "data:aerodynamics:wing:cruise:CL_alpha",
+        ] = (
+            -(cl_opt - cl0_clean) / cl_alpha ** 2.0 * 180.0 / np.pi
+        )

--- a/src/fastga/models/aerodynamics/components/compute_cl_extreme.py
+++ b/src/fastga/models/aerodynamics/components/compute_cl_extreme.py
@@ -36,7 +36,27 @@ class ComputeAircraftMaxCl(om.ExplicitComponent):
         self.add_output("data:aerodynamics:aircraft:takeoff:CL_max")
         self.add_output("data:aerodynamics:aircraft:landing:CL_max")
 
-        self.declare_partials("*", "*", method="fd")
+        self.declare_partials(
+            "data:aerodynamics:aircraft:takeoff:CL_max",
+            "data:aerodynamics:wing:low_speed:CL_max_clean",
+            val=1.0,
+        )
+        self.declare_partials(
+            "data:aerodynamics:aircraft:takeoff:CL_max",
+            "data:aerodynamics:flaps:takeoff:CL_max",
+            val=1.0,
+        )
+
+        self.declare_partials(
+            "data:aerodynamics:aircraft:landing:CL_max",
+            "data:aerodynamics:wing:low_speed:CL_max_clean",
+            val=1.0,
+        )
+        self.declare_partials(
+            "data:aerodynamics:aircraft:landing:CL_max",
+            "data:aerodynamics:flaps:landing:CL_max",
+            val=1.0,
+        )
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 

--- a/src/fastga/models/aerodynamics/components/compute_effective_efficiency_prop.py
+++ b/src/fastga/models/aerodynamics/components/compute_effective_efficiency_prop.py
@@ -55,6 +55,8 @@ class ComputeEffectiveEfficiencyPropeller(om.ExplicitComponent):
                 "efficiency due to the presence of cowling (fuselage or nacelle) behind the "
                 "propeller",
             )
+
+            self.declare_partials("*", "*", method="fd")
         else:
             self.add_input("data:aerodynamics:nacelles:cruise:CD0", val=np.nan)
             self.add_input("data:aerodynamics:fuselage:cruise:CD0", val=np.nan)
@@ -67,7 +69,7 @@ class ComputeEffectiveEfficiencyPropeller(om.ExplicitComponent):
                 "propeller",
             )
 
-        self.declare_partials("*", "*", method="fd")
+            self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 

--- a/src/fastga/models/aerodynamics/external/propeller_code/propeller_core.py
+++ b/src/fastga/models/aerodynamics/external/propeller_code/propeller_core.py
@@ -15,7 +15,7 @@
 import logging
 
 import numpy as np
-from scipy.optimize import fsolve
+from scipy.optimize import root
 
 import openmdao.api as om
 
@@ -160,10 +160,10 @@ class PropellerCoreModule(om.ExplicitComponent):
         for idx, _ in enumerate(radius):
 
             # Solve BEM vs. disk theory system of equations
-            speed_vect = fsolve(
-                self.delta,
-                speed_vect,
-                (
+            speed_vect = root(
+                fun=self.delta,
+                x0=speed_vect,
+                args=(
                     radius[idx],
                     radius_min,
                     radius_max,
@@ -179,8 +179,9 @@ class PropellerCoreModule(om.ExplicitComponent):
                     atm,
                     reference_reynolds,
                 ),
-                xtol=1e-3,
-            )
+                method="hybr",
+                options={"xtol": 1e-3},
+            ).x
             vi_vect[idx] = speed_vect[0]
             vt_vect[idx] = speed_vect[1]
             results = self.bem_theory(

--- a/src/fastga/models/aerodynamics/unitary_tests/test_functions.py
+++ b/src/fastga/models/aerodynamics/unitary_tests/test_functions.py
@@ -948,6 +948,8 @@ def extreme_cl(
         cl_max_landing_wing, abs=1e-2
     )
 
+    problem.check_partials(compact_print=True)
+
 
 def l_d_max(
     XML_FILE: str, l_d_max_: float, optimal_cl: float, optimal_cd: float, optimal_alpha: float
@@ -968,6 +970,8 @@ def l_d_max(
     assert problem.get_val(
         "data:aerodynamics:aircraft:cruise:optimal_alpha", units="deg"
     ) == pytest.approx(optimal_alpha, abs=1e-2)
+
+    problem.check_partials(compact_print=True)
 
 
 def cnbeta(XML_FILE: str, cn_beta_fus: float):

--- a/src/fastga/models/aerodynamics/unitary_tests/test_functions.py
+++ b/src/fastga/models/aerodynamics/unitary_tests/test_functions.py
@@ -270,6 +270,8 @@ def cd0_high_speed(
     )
     assert cd0_total_cal == pytest.approx(cd0_total, abs=1e-5)
 
+    problem.check_partials(compact_print=True)
+
 
 def cd0_low_speed(
     XML_FILE: str,
@@ -315,6 +317,8 @@ def cd0_low_speed(
         + problem["data:aerodynamics:other:low_speed:CD0"]
     )
     assert cd0_total_cal == pytest.approx(cd0_total, abs=1e-5)
+
+    problem.check_partials(compact_print=True)
 
 
 def polar(

--- a/src/fastga/models/geometry/geom_components/wing/compute_wing.py
+++ b/src/fastga/models/geometry/geom_components/wing/compute_wing.py
@@ -47,13 +47,13 @@ class ComputeWingGeometry(Group):
             "wing_y", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_SPAN), promotes=["*"]
         )
         self.add_subsystem(
-            "wing_z", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_HEIGHT), promotes=["*"]
-        )
-        self.add_subsystem(
             "wing_l1l4", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_L1_L4), promotes=["*"]
         )
         self.add_subsystem(
             "wing_l2l3", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_L2_L3), promotes=["*"]
+        )
+        self.add_subsystem(
+            "wing_z", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_HEIGHT), promotes=["*"]
         )
         self.add_subsystem(
             "wing_x", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_X_LOCAL), promotes=["*"]

--- a/src/fastga/models/loops/unitary_tests/test_loops.py
+++ b/src/fastga/models/loops/unitary_tests/test_loops.py
@@ -38,6 +38,7 @@ from ..wing_area_component.wing_area_cl_equilibrium import (
 )
 from ..wing_area_component.update_wing_area import UpdateWingArea
 from ..update_wing_area_group import UpdateWingAreaGroup
+from ..update_wing_position import UpdateWingPosition
 
 from tests.testing_utilities import get_indep_var_comp, list_inputs, run_system
 
@@ -272,3 +273,15 @@ def test_update_wing_area():
     assert_allclose(problem_aero["data:geometry:wing:area"], 15.0, atol=1e-3)
 
     # _ = problem_aero.check_partials(compact_print=True)
+
+
+def test_update_wing_position():
+
+    ivc = get_indep_var_comp(list_inputs(UpdateWingPosition()), __file__, "beechcraft_76.xml")
+
+    problem = run_system(UpdateWingPosition(), ivc)
+    assert_allclose(
+        problem.get_val("data:geometry:wing:MAC:at25percent:x", units="m"), 3.4550, atol=1e-3
+    )
+
+    problem.check_partials(compact_print=True)

--- a/src/fastga/models/loops/update_wing_position.py
+++ b/src/fastga/models/loops/update_wing_position.py
@@ -49,3 +49,25 @@ class UpdateWingPosition(om.ExplicitComponent):
         )
 
         outputs["data:geometry:wing:MAC:at25percent:x"] = mac_position
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+        static_margin = inputs["data:handling_qualities:stick_fixed_static_margin"]
+        target_static_margin = inputs["data:handling_qualities:static_margin:target"]
+        l0_wing = inputs["data:geometry:wing:MAC:length"]
+        cg_ratio = inputs["data:weight:aircraft:CG:aft:MAC_position"]
+        cg_x = inputs["data:weight:aircraft:CG:aft:x"]
+
+        partials[
+            "data:geometry:wing:MAC:at25percent:x",
+            "data:handling_qualities:stick_fixed_static_margin",
+        ] = -l0_wing
+        partials[
+            "data:geometry:wing:MAC:at25percent:x", "data:handling_qualities:static_margin:target"
+        ] = l0_wing
+        partials["data:geometry:wing:MAC:at25percent:x", "data:geometry:wing:MAC:length"] = (
+            0.25 - cg_ratio - (static_margin - target_static_margin)
+        )
+        partials[
+            "data:geometry:wing:MAC:at25percent:x", "data:weight:aircraft:CG:aft:MAC_position"
+        ] = -l0_wing
+        partials["data:geometry:wing:MAC:at25percent:x", "data:weight:aircraft:CG:aft:x"] = 1.0

--- a/src/fastga/models/loops/update_wing_position.py
+++ b/src/fastga/models/loops/update_wing_position.py
@@ -30,9 +30,9 @@ class UpdateWingPosition(om.ExplicitComponent):
         self.add_input("data:weight:aircraft:CG:aft:MAC_position", val=np.nan)
         self.add_input("data:weight:aircraft:CG:aft:x", val=np.nan, units="m")
 
-        self.add_output("data:geometry:wing:MAC:at25percent:x", units="m")
+        self.add_output("data:geometry:wing:MAC:at25percent:x", units="m", val=3.5)
 
-        self.declare_partials(of="*", wrt="*", method="fd")
+        self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         static_margin = inputs["data:handling_qualities:stick_fixed_static_margin"]
@@ -55,7 +55,6 @@ class UpdateWingPosition(om.ExplicitComponent):
         target_static_margin = inputs["data:handling_qualities:static_margin:target"]
         l0_wing = inputs["data:geometry:wing:MAC:length"]
         cg_ratio = inputs["data:weight:aircraft:CG:aft:MAC_position"]
-        cg_x = inputs["data:weight:aircraft:CG:aft:x"]
 
         partials[
             "data:geometry:wing:MAC:at25percent:x",

--- a/src/fastga/models/performances/mission/mission.py
+++ b/src/fastga/models/performances/mission/mission.py
@@ -44,17 +44,12 @@ class Mission(om.Group):
     """
     Computes analytically the fuel mass necessary for each part of the flight cycle.
 
-    Loop on the distance crossed during descent and cruise distance/fuel mass.
-
+    This component previously used to have a solver acting on the cruise range to ensure that
+    range was equal to the sum of the ranges of the different flight phase. The solver was
+    removed because, inside a global OAD process, the default global solver can handle the
+    convergence of the cruise range just fine. This means that if this components is to be used
+    on its own (like in the tests or payload range computation), a solver should be added.
     """
-
-    def __init__(self, **kwargs):
-        """Defining solvers for mission computation resolution."""
-        super().__init__(**kwargs)
-
-        # Solvers setup
-        self.nonlinear_solver = om.NonlinearBlockGS()
-        self.linear_solver = om.LinearBlockGS()
 
     def initialize(self):
         self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
@@ -110,17 +105,6 @@ class Mission(om.Group):
             promotes=["*"],
         )
         self.add_subsystem("update_fw", UpdateFW(), promotes=["*"])
-
-        # Solvers setup
-        self.nonlinear_solver.options["debug_print"] = True
-        self.nonlinear_solver.options["iprint"] = 0
-        self.nonlinear_solver.options["maxiter"] = 100
-        self.nonlinear_solver.options["rtol"] = 1e-2
-
-        # self.linear_solver.options["err_on_non_converge"] = True
-        self.linear_solver.options["iprint"] = 0
-        self.linear_solver.options["maxiter"] = 10
-        self.linear_solver.options["rtol"] = 1e-2
 
 
 class UpdateFW(om.ExplicitComponent):

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -100,6 +100,7 @@ class ComputeClimb(DynamicEquilibrium):
                 _LOGGER.info("Failed to remove %s file!", self.options["out_file"])
 
         propulsion_model = self._engine_wrapper.get_model(inputs)
+        wing_area = inputs["data:geometry:wing:area"]
         cruise_altitude = inputs["data:mission:sizing:main_route:cruise:altitude"]
         mtow = inputs["data:weight:aircraft:MTOW"]
         m_to = inputs["data:mission:sizing:taxi_out:fuel"]
@@ -175,6 +176,9 @@ class ComputeClimb(DynamicEquilibrium):
                 _LOGGER.warning("Thrust rate is above 1.0, value clipped at 1.0")
 
             # Save results
+            self.compute_flight_point_drag(
+                flight_point=flight_point, equilibrium_result=previous_step, wing_area=wing_area
+            )
             self.add_flight_point(flight_point=flight_point, equilibrium_result=previous_step)
 
             consumed_mass_1s = propulsion_model.get_consumed_mass(flight_point, 1.0)

--- a/src/fastga/models/performances/mission/mission_components/cruise.py
+++ b/src/fastga/models/performances/mission/mission_components/cruise.py
@@ -97,6 +97,7 @@ class ComputeCruise(DynamicEquilibrium):
                 "Cruise distance is negative, check the input value mainly the range "
                 "and/or the climb and descent inputs"
             )
+        wing_area = inputs["data:geometry:wing:area"]
         cruise_altitude = inputs["data:mission:sizing:main_route:cruise:altitude"]
         mtow = inputs["data:weight:aircraft:MTOW"]
         m_to = inputs["data:mission:sizing:taxi_out:fuel"]
@@ -147,6 +148,9 @@ class ComputeCruise(DynamicEquilibrium):
                 _LOGGER.warning("Thrust rate is above 1.0, value clipped at 1.0")
 
             # Save results
+            self.compute_flight_point_drag(
+                flight_point=flight_point, equilibrium_result=previous_step, wing_area=wing_area
+            )
             self.add_flight_point(flight_point=flight_point, equilibrium_result=previous_step)
 
             consumed_mass_1s = propulsion_model.get_consumed_mass(flight_point, 1.0)

--- a/src/fastga/models/performances/mission/mission_components/descent.py
+++ b/src/fastga/models/performances/mission/mission_components/descent.py
@@ -94,6 +94,7 @@ class ComputeDescent(DynamicEquilibrium):
             # noinspection PyBroadException
             flight_point_df = None
 
+        wing_area = inputs["data:geometry:wing:area"]
         propulsion_model = self._engine_wrapper.get_model(inputs)
         cruise_altitude = inputs["data:mission:sizing:main_route:cruise:altitude"]
         descent_rate = inputs["data:mission:sizing:main_route:descent:descent_rate"]
@@ -181,6 +182,9 @@ class ComputeDescent(DynamicEquilibrium):
             propulsion_model.compute_flight_points(flight_point)
 
             # Save results
+            self.compute_flight_point_drag(
+                flight_point=flight_point, equilibrium_result=previous_step, wing_area=wing_area
+            )
             self.add_flight_point(flight_point=flight_point, equilibrium_result=previous_step)
             consumed_mass_1s = propulsion_model.get_consumed_mass(flight_point, 1.0)
 

--- a/src/fastga/models/performances/unitary_tests/test_beechcraft_76.py
+++ b/src/fastga/models/performances/unitary_tests/test_beechcraft_76.py
@@ -14,9 +14,9 @@ Test takeoff module.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from openmdao.core.group import Group
 import pytest
 import numpy as np
+import openmdao.api as om
 
 from fastga.models.performances.mission.takeoff import (
     TakeOffPhase,
@@ -206,7 +206,7 @@ def test_compute_climb_speed():
     """Tests climb phase"""
 
     # Research independent input value in .xml file
-    group = Group()
+    group = om.Group()
     group.add_subsystem("climb", ComputeClimbSpeed(), promotes=["*"])
     ivc = get_indep_var_comp(list_inputs(group), __file__, XML_FILE)
 
@@ -220,7 +220,7 @@ def test_compute_climb():
     """Tests climb phase"""
 
     # Research independent input value in .xml file
-    group = Group()
+    group = om.Group()
     group.add_subsystem("in_flight_cg_variation", InFlightCGVariation(), promotes=["*"])
     group.add_subsystem("climb", ComputeClimb(propulsion_id=ENGINE_WRAPPER), promotes=["*"])
     ivc = get_indep_var_comp(list_inputs(group), __file__, XML_FILE)
@@ -241,7 +241,7 @@ def test_compute_cruise():
     """Tests cruise phase"""
 
     # Research independent input value in .xml file
-    group = Group()
+    group = om.Group()
     group.add_subsystem("in_flight_cg_variation", InFlightCGVariation(), promotes=["*"])
     group.add_subsystem("cruise", ComputeCruise(propulsion_id=ENGINE_WRAPPER), promotes=["*"])
     ivc = get_indep_var_comp(list_inputs(group), __file__, XML_FILE)
@@ -258,7 +258,7 @@ def test_compute_descent_speed():
     """Tests climb phase"""
 
     # Research independent input value in .xml file
-    group = Group()
+    group = om.Group()
     group.add_subsystem("climb", ComputeDescentSpeed(), promotes=["*"])
     ivc = get_indep_var_comp(list_inputs(group), __file__, XML_FILE)
 
@@ -272,7 +272,7 @@ def test_compute_descent():
     """Tests descent phase"""
 
     # Research independent input value in .xml file
-    group = Group()
+    group = om.Group()
     group.add_subsystem("in_flight_cg_variation", InFlightCGVariation(), promotes=["*"])
     group.add_subsystem("descent", ComputeDescent(propulsion_id=ENGINE_WRAPPER), promotes=["*"])
     ivc = get_indep_var_comp(list_inputs(group), __file__, XML_FILE)
@@ -293,7 +293,7 @@ def test_compute_reserve():
     """Tests reserve phase"""
 
     # Research independent input value in .xml file
-    group = Group()
+    group = om.Group()
     group.add_subsystem("reserve", ComputeReserve(), promotes=["*"])
     ivc = get_indep_var_comp(list_inputs(group), __file__, XML_FILE)
 
@@ -311,7 +311,7 @@ def test_loop_cruise_distance():
 
     # Run problem and check obtained value(s) is/(are) correct
     # noinspection PyTypeChecker
-    problem = run_system(Mission(propulsion_id=ENGINE_WRAPPER), ivc)
+    problem = run_system(Mission(propulsion_id=ENGINE_WRAPPER), ivc, add_solvers=True)
     m_total = problem.get_val("data:mission:sizing:fuel", units="kg")
     assert m_total == pytest.approx(140, abs=1)
     climb_distance = problem.get_val("data:mission:sizing:main_route:climb:distance", units="NM")

--- a/src/fastga/models/performances/unitary_tests/test_cirrus_sr22.py
+++ b/src/fastga/models/performances/unitary_tests/test_cirrus_sr22.py
@@ -316,7 +316,7 @@ def test_loop_cruise_distance():
 
     # Run problem and check obtained value(s) is/(are) correct
     # noinspection PyTypeChecker
-    problem = run_system(Mission(propulsion_id=ENGINE_WRAPPER), ivc)
+    problem = run_system(Mission(propulsion_id=ENGINE_WRAPPER), ivc, add_solvers=True)
     m_total = problem.get_val("data:mission:sizing:fuel", units="kg")
     assert m_total == pytest.approx(163, abs=1)
     climb_distance = problem.get_val("data:mission:sizing:main_route:climb:distance", units="NM")

--- a/src/fastga/models/performances/unitary_tests/test_daher_tbm900.py
+++ b/src/fastga/models/performances/unitary_tests/test_daher_tbm900.py
@@ -311,7 +311,7 @@ def test_loop_cruise_distance():
 
     # Run problem and check obtained value(s) is/(are) correct
     # noinspection PyTypeChecker
-    problem = run_system(Mission(propulsion_id=ENGINE_WRAPPER), ivc)
+    problem = run_system(Mission(propulsion_id=ENGINE_WRAPPER), ivc, add_solvers=True)
     m_total = problem.get_val("data:mission:sizing:fuel", units="kg")
     assert m_total == pytest.approx(742, abs=1)
     climb_distance = problem.get_val("data:mission:sizing:main_route:climb:distance", units="NM")

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a2_fuselage_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a2_fuselage_cg.py
@@ -71,8 +71,6 @@ class ComputeFuselageCG(ExplicitComponent):
     def compute_partials(self, inputs, partials, discrete_inputs=None):
 
         prop_layout = inputs["data:geometry:propulsion:engine:layout"]
-        fus_length = inputs["data:geometry:fuselage:length"]
-        lav = inputs["data:geometry:fuselage:front_length"]
 
         # Fuselage gravity center
         if prop_layout == 1.0:  # Wing mounted

--- a/src/fastga/models/weight/cg/cg_components/ratio_aft.py
+++ b/src/fastga/models/weight/cg/cg_components/ratio_aft.py
@@ -41,14 +41,6 @@ from ..cg_components.constants import (
     SUBMODEL_AIRCRAFT_X_CG_RATIO, "fastga.submodel.weight.cg.aircraft_empty.x_ratio.legacy"
 )
 class ComputeCGRatioAircraftEmpty(om.Group):
-    def __init__(self, **kwargs):
-        """Defining solvers for aircraft empty cg computation resolution."""
-        super().__init__(**kwargs)
-
-        # Solvers setup
-        self.nonlinear_solver = om.NonlinearBlockGS()
-        self.linear_solver = om.LinearBlockGS()
-
     def setup(self):
         self.add_subsystem(
             "wing_cg", oad.RegisterSubmodel.get_submodel(SUBMODEL_WING_CG), promotes=["*"]
@@ -106,16 +98,6 @@ class ComputeCGRatioAircraftEmpty(om.Group):
             "z_cg", oad.RegisterSubmodel.get_submodel(SUBMODEL_AIRCRAFT_Z_CG), promotes=["*"]
         )
         self.add_subsystem("cg_ratio", CGRatio(), promotes=["*"])
-
-        # Solvers setup
-        self.nonlinear_solver.options["debug_print"] = True
-        self.nonlinear_solver.options["err_on_non_converge"] = True
-        self.nonlinear_solver.options["iprint"] = 0
-        self.nonlinear_solver.options["maxiter"] = 50
-
-        self.linear_solver.options["err_on_non_converge"] = True
-        self.linear_solver.options["iprint"] = 0
-        self.linear_solver.options["maxiter"] = 10
 
 
 @oad.RegisterSubmodel(SUBMODEL_AIRCRAFT_X_CG, "fastga.submodel.weight.cg.aircraft_empty.x.legacy")

--- a/src/fastga/models/weight/mass_breakdown/c_systems/sum.py
+++ b/src/fastga/models/weight/mass_breakdown/c_systems/sum.py
@@ -30,15 +30,12 @@ from ..constants import SUBMODEL_SYSTEMS_MASS
 class SystemsWeight(om.Group):
     """Computes mass of systems."""
 
-    def __init__(self, **kwargs):
-        """Defining solvers for systems weight computation resolution."""
-        super().__init__(**kwargs)
-
-        # Solvers setup
-        self.nonlinear_solver = om.NonlinearBlockGS()
-        self.linear_solver = om.LinearBlockGS()
-
     def setup(self):
+        self.add_subsystem(
+            "navigation_systems_weight",
+            oad.RegisterSubmodel.get_submodel(SUBMODEL_AVIONICS_SYSTEM_MASS),
+            promotes=["*"],
+        )
         self.add_subsystem(
             "power_systems_weight",
             oad.RegisterSubmodel.get_submodel(SUBMODEL_POWER_SYSTEM_MASS),
@@ -47,11 +44,6 @@ class SystemsWeight(om.Group):
         self.add_subsystem(
             "life_support_systems_weight",
             oad.RegisterSubmodel.get_submodel(SUBMODEL_LIFE_SUPPORT_SYSTEM_MASS),
-            promotes=["*"],
-        )
-        self.add_subsystem(
-            "navigation_systems_weight",
-            oad.RegisterSubmodel.get_submodel(SUBMODEL_AVIONICS_SYSTEM_MASS),
             promotes=["*"],
         )
         self.add_subsystem(
@@ -81,13 +73,3 @@ class SystemsWeight(om.Group):
         )
 
         self.add_subsystem("systems_weight_sum", weight_sum, promotes=["*"])
-
-        # Solvers setup
-        self.nonlinear_solver.options["debug_print"] = True
-        self.nonlinear_solver.options["err_on_non_converge"] = True
-        self.nonlinear_solver.options["iprint"] = 0
-        self.nonlinear_solver.options["maxiter"] = 50
-
-        self.linear_solver.options["err_on_non_converge"] = True
-        self.linear_solver.options["iprint"] = 0
-        self.linear_solver.options["maxiter"] = 10

--- a/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
+++ b/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
@@ -49,6 +49,14 @@ class MassBreakdown(om.Group):
                          design payload mass and maximum payload mass must be provided.
     """
 
+    def __init__(self, **kwargs):
+        """Defining solvers for mass breakdown computation resolution."""
+        super().__init__(**kwargs)
+
+        # Solvers setup
+        self.nonlinear_solver = om.NonlinearBlockGS()
+        self.linear_solver = om.LinearBlockGS()
+
     def initialize(self):
         self.options.declare(PAYLOAD_FROM_NPAX, types=bool, default=True)
         self.options.declare("propulsion_id", default="", types=str)
@@ -67,6 +75,14 @@ class MassBreakdown(om.Group):
         self.add_subsystem("update_mzfw_and_mlw", UpdateMLWandMZFW(), promotes=["*"])
 
         # Solvers setup
+        self.nonlinear_solver.options["debug_print"] = True
+        self.nonlinear_solver.options["err_on_non_converge"] = True
+        self.nonlinear_solver.options["iprint"] = 0
+        self.nonlinear_solver.options["maxiter"] = 50
+
+        self.linear_solver.options["err_on_non_converge"] = True
+        self.linear_solver.options["iprint"] = 0
+        self.linear_solver.options["maxiter"] = 10
 
 
 @oad.RegisterSubmodel(SUBMODEL_OWE, "fastga.submodel.weight.mass.owe.legacy")

--- a/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
+++ b/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
@@ -49,14 +49,6 @@ class MassBreakdown(om.Group):
                          design payload mass and maximum payload mass must be provided.
     """
 
-    def __init__(self, **kwargs):
-        """Defining solvers for mass breakdown computation resolution."""
-        super().__init__(**kwargs)
-
-        # Solvers setup
-        self.nonlinear_solver = om.NonlinearBlockGS()
-        self.linear_solver = om.LinearBlockGS()
-
     def initialize(self):
         self.options.declare(PAYLOAD_FROM_NPAX, types=bool, default=True)
         self.options.declare("propulsion_id", default="", types=str)
@@ -75,14 +67,6 @@ class MassBreakdown(om.Group):
         self.add_subsystem("update_mzfw_and_mlw", UpdateMLWandMZFW(), promotes=["*"])
 
         # Solvers setup
-        self.nonlinear_solver.options["debug_print"] = True
-        self.nonlinear_solver.options["err_on_non_converge"] = True
-        self.nonlinear_solver.options["iprint"] = 0
-        self.nonlinear_solver.options["maxiter"] = 50
-
-        self.linear_solver.options["err_on_non_converge"] = True
-        self.linear_solver.options["iprint"] = 0
-        self.linear_solver.options["maxiter"] = 10
 
 
 @oad.RegisterSubmodel(SUBMODEL_OWE, "fastga.submodel.weight.mass.owe.legacy")

--- a/src/fastga/models/weight/mass_breakdown/update_mlw_and_mzfw.py
+++ b/src/fastga/models/weight/mass_breakdown/update_mlw_and_mzfw.py
@@ -76,9 +76,7 @@ class UpdateMLWandMZFW(ExplicitComponent):
     def compute_partials(self, inputs, partials, discrete_inputs=None):
 
         owe = inputs["data:weight:aircraft:OWE"]
-        mtow = inputs["data:weight:aircraft:MTOW"]
         max_pl = inputs["data:weight:aircraft:max_payload"]
-        pl = inputs["data:weight:aircraft:payload"]
         cruise_ktas = inputs["data:TLAR:v_cruise"]
 
         mzfw = owe + max_pl

--- a/src/fastga/models/weight/mass_breakdown/update_mtow.py
+++ b/src/fastga/models/weight/mass_breakdown/update_mtow.py
@@ -33,7 +33,8 @@ class UpdateMTOW(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:MTOW", 1500.0, units="kg")
 
-        self.declare_partials("*", "*", method="fd")
+        self.declare_partials("data:weight:aircraft:MTOW", "data:weight:aircraft:ZFW", val=1.0)
+        self.declare_partials("data:weight:aircraft:MTOW", "data:mission:sizing:fuel", val=1.0)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         zfw = inputs["data:weight:aircraft:ZFW"]

--- a/src/fastga/notebooks/tutorial/03_analysis.ipynb
+++ b/src/fastga/notebooks/tutorial/03_analysis.ipynb
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Consider we want to generate a second aircraft geometry modifying the wing by an increase of 15% of the spanwithout changing the first part of the wing.\n",
+    "Consider we want to generate a second aircraft geometry modifying the wing by an increase of 15% of the span without changing the first part of the wing.\n",
     "\n",
     "**We have the following relationships:**\n",
     "\n",
@@ -197,11 +197,12 @@
     "\n",
     "# Calculate parameters\n",
     "taper_ratio_new = taper_func(1.15)\n",
+    "aspect_ratio_new = (span_old * 1.15) ** 2 / area\n",
     "area = area_func(taper_ratio_new, 1.15)\n",
     "\n",
     "# Print results\n",
     "print(\"area=\" + str(area))\n",
-    "print(\"aspect_ratio=\" + str((span_old * 1.15) ** 2 / area))\n",
+    "print(\"aspect_ratio=\" + str(aspect_ratio_new))\n",
     "print(\"taper_ratio=\" + str(taper_ratio_new))"
    ]
   },
@@ -220,9 +221,9 @@
    "source": [
     "# Compute geometry\n",
     "inputs_dict = {\n",
-    "    \"data:geometry:wing:area\": (19.3315, \"m**2\"),\n",
-    "    \"data:geometry:wing:aspect_ratio\": (9.083, None),\n",
-    "    \"data:geometry:wing:taper_ratio\": (1.0, None),\n",
+    "    \"data:geometry:wing:area\": (area, \"m**2\"),\n",
+    "    \"data:geometry:wing:aspect_ratio\": (aspect_ratio_new, None),\n",
+    "    \"data:geometry:wing:taper_ratio\": (taper_ratio_new, None),\n",
     "}\n",
     "outputs_dict = compute_geometry(inputs_dict)\n",
     "\n",
@@ -382,7 +383,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we are gona plot the results for both aicrafts."
+    "Now, we are going to plot the results for both aicrafts."
    ]
   },
   {

--- a/src/fastga/notebooks/tutorial/data/beechcraft_76.xml
+++ b/src/fastga/notebooks/tutorial/data/beechcraft_76.xml
@@ -186,6 +186,13 @@
     </weight>
   </data>
   <settings>
+    <aerodynamics>
+      <aircraft>
+        <undesirable_drag>
+          <k_factor>1.25</k_factor>
+        </undesirable_drag>
+      </aircraft>
+    </aerodynamics>
     <propulsion>
       <IC_engine>
         <k_factor_sfc>1.1</k_factor_sfc>

--- a/src/fastga/notebooks/tutorial/data/beechcraft_76_loads.xml
+++ b/src/fastga/notebooks/tutorial/data/beechcraft_76_loads.xml
@@ -291,6 +291,11 @@
       </propulsion>
     </weight>
     <aerodynamics>
+      <aircraft>
+        <undesirable_drag>
+          <k_factor>1.25</k_factor>
+        </undesirable_drag>
+      </aircraft>
       <aileron>
         <tip_effect>
           <k_factor>0.9</k_factor>

--- a/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
+++ b/src/fastga/notebooks/tutorial/data/reference_aircraft.xml
@@ -292,6 +292,11 @@
       </propulsion>
     </weight>
     <aerodynamics>
+      <aircraft>
+        <undesirable_drag>
+          <k_factor>1.25</k_factor>
+        </undesirable_drag>
+      </aircraft>
       <aileron>
         <tip_effect>
           <k_factor>0.9</k_factor>

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -50,8 +50,8 @@ def run_system(
     model.add_subsystem("component", component, promotes=["*"])
     if add_solvers:
         # noinspection PyTypeChecker
-        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
-        model.linear_solver = om.DirectSolver()
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
     if check:
         print("\n")


### PR DESCRIPTION
This PR contains a few changes to the code:
- The addition of partial derivatives on some aerodynamic components
- The addition of an input corresponding to the the CRUD factor which used to be hardcoded ("settings:aerodynamics:aircraft:undesirable_drag:k_factor"), this closes #146
- Some change of model position in the default configuration file and the corresponding slight change in results in the integration processes
- The deletion of the solver in the mission module, meaning the convergence on the range is now handled by the global solver, which saves a lot of time. See the remark in mission.py
- The computation of the aircraft drag at each point of the flight. This closes #191 