### PR TITLE
Allowing newer version of stdatm

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3034,7 +3034,8 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
@@ -3856,4 +3857,4 @@ jupyterlab = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7, <3.10"
-content-hash = "02d6943e24a7a9d917ccb16e8eef038514e4b649e912dd93d37a87651bf7f82c"
+content-hash = "72797972bc941bf13ed7eadde607e2ebbc64ccb9619481217b26c740e86011f4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3857,4 +3857,4 @@ jupyterlab = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7, <3.10"
-content-hash = "72797972bc941bf13ed7eadde607e2ebbc64ccb9619481217b26c740e86011f4"
+content-hash = "e16244356589135f9897b10d4335b0b5d9a6d1fa85fa568c4efb2fbb369d0d54"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 # doing again the commit including changes in docs/requirements.txt will succeed.
 python = "^3.7, <3.10"
 fast-oad-core = ">=1.3.3"
-stdatm = "0.2.0"
+stdatm = "*"
 
 [tool.poetry.extras]
 jupyterlab = ["jupyterlab"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 # doing again the commit including changes in docs/requirements.txt will succeed.
 python = "^3.7, <3.10"
 fast-oad-core = ">=1.3.3"
-stdatm = "*"
+stdatm = ">=0.2.0"
 
 [tool.poetry.extras]
 jupyterlab = ["jupyterlab"]


### PR DESCRIPTION
Didn't pay much attention to it when originally specifying this dependency but the way we previously specified `stdatm` did not allow newer versions. This should be fixed with that PR