### PR TITLE
Tests on Ubuntu latest & timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,13 @@ on:
 
 jobs:
   tests:
+#    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') }}
     strategy:
       matrix:
         python-version: [ "3.8", "3.10", "3.11" ]
-        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         # Exceptions:
         # - Python 3.8 and 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
         #   https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
@@ -31,7 +32,7 @@ jobs:
           - { python-version: "3.8", os: "macos-13" }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Poetry
         run: pipx install poetry==1.8.3
@@ -66,7 +67,7 @@ jobs:
         shell: bash
 
       - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
         if: ${{ runner.os == 'Linux' && matrix.python-version == '3.10' }} # This step runs only on Linux
         with:
           project-token: ${{ secrets.codacy }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   tests:
-#    timeout-minutes: 60
+    timeout-minutes: 120  # On 17/04/2025: to avoid tests that take too long
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') }}
     strategy:


### PR DESCRIPTION
This PR moves the test from ubuntu-20.04 which will soon not be supported anymore and moves them back to ubuntu latest with which wa had some issues with infinite runtimes. To work around that, a timeout set at 2h has been added.

This PR closes #231 