### PR TITLE
Dev abandon interp1d

### DIFF
--- a/src/fastga/models/aerodynamics/components/compute_vn.py
+++ b/src/fastga/models/aerodynamics/components/compute_vn.py
@@ -18,7 +18,7 @@ import warnings
 import numpy as np
 import openmdao.api as om
 import scipy.optimize as optimize
-from scipy.interpolate import CubicSpline
+from scipy.interpolate import make_interp_spline
 from scipy.constants import g, knot, foot, lbf
 
 # noinspection PyProtectedMember
@@ -334,7 +334,7 @@ class ComputeVN(om.ExplicitComponent):
         for mach in mach_interp:
             v_interp.append(float(mach * atm.speed_of_sound))
         cl_alpha_interp = inputs["data:aerodynamics:aircraft:mach_interpolation:CL_alpha_vector"]
-        cl_alpha_fct = CubicSpline(v_interp, cl_alpha_interp)
+        cl_alpha_fct = make_interp_spline(v_interp, cl_alpha_interp, k=2)
 
         # We will now establish the minimum limit maneuvering load factors outside of gust load
         # factors. Th designer can take higher load factor if he so wish. As will later be done

--- a/src/fastga/models/aerodynamics/components/compute_vn.py
+++ b/src/fastga/models/aerodynamics/components/compute_vn.py
@@ -18,7 +18,7 @@ import warnings
 import numpy as np
 import openmdao.api as om
 import scipy.optimize as optimize
-from scipy import interpolate
+from scipy.interpolate import CubicSpline
 from scipy.constants import g, knot, foot, lbf
 
 # noinspection PyProtectedMember
@@ -334,9 +334,7 @@ class ComputeVN(om.ExplicitComponent):
         for mach in mach_interp:
             v_interp.append(float(mach * atm.speed_of_sound))
         cl_alpha_interp = inputs["data:aerodynamics:aircraft:mach_interpolation:CL_alpha_vector"]
-        cl_alpha_fct = interpolate.interp1d(
-            v_interp, cl_alpha_interp, fill_value="extrapolate", kind="quadratic"
-        )
+        cl_alpha_fct = CubicSpline(v_interp, cl_alpha_interp)
 
         # We will now establish the minimum limit maneuvering load factors outside of gust load
         # factors. Th designer can take higher load factor if he so wish. As will later be done

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -16,7 +16,6 @@ from typing import Union, Tuple
 
 import numpy as np
 import fastoad.api as oad
-from scipy import interpolate
 
 from .figure_digitization import FigureDigitization
 from ..constants import SUBMODEL_DELTA_HIGH_LIFT

--- a/src/fastga/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastga/models/aerodynamics/components/high_lift_aero.py
@@ -278,9 +278,11 @@ class ComputeDeltaHighLift(FigureDigitization):
             k1_0_30 = (
                 -0.000 * chord_ratio**3 + 4.694 * chord_ratio**2 + 4.372 * chord_ratio - 0.0031
             )
-            flap_chord_contribution = interpolate.interp1d(
-                [0.12, 0.21, 0.30], [float(k1_0_12), float(k1_0_21), float(k1_0_30)]
-            )(np.clip(thickness_ratio, 0.12, 0.30))
+            flap_chord_contribution = np.interp(
+                np.clip(thickness_ratio, 0.12, 0.30),
+                [0.12, 0.21, 0.30],
+                [float(k1_0_12), float(k1_0_21), float(k1_0_30)],
+            )
             flap_deflection_contribution = (
                 -3.795e-7 * flap_angle**3
                 + 5.387e-5 * flap_angle**2
@@ -303,9 +305,9 @@ class ComputeDeltaHighLift(FigureDigitization):
                 + 3.4564 * chord_ratio
                 - 0.0054
             )
-            flap_chord_contribution = interpolate.interp1d(
-                [0.12, 0.21], [float(k1_0_12), float(k1_0_21)]
-            )(np.clip(thickness_ratio, 0.12, 0.21))
+            flap_chord_contribution = np.interp(
+                np.clip(thickness_ratio, 0.12, 0.21), [0.12, 0.21], [float(k1_0_12), float(k1_0_21)]
+            )
             k2_0_12 = (
                 -3.9877e-12 * flap_angle**6
                 + 1.1685e-9 * flap_angle**5
@@ -333,9 +335,11 @@ class ComputeDeltaHighLift(FigureDigitization):
                 - 41677e-3 * flap_angle
                 + 6.749e-4
             )
-            flap_deflection_contribution = interpolate.interp1d(
-                [0.12, 0.21, 0.30], [float(k2_0_12), float(k2_0_21), float(k2_0_30)]
-            )(np.clip(thickness_ratio, 0.12, 0.30))
+            flap_deflection_contribution = np.interp(
+                np.clip(thickness_ratio, 0.12, 0.30),
+                [0.12, 0.21, 0.30],
+                [float(k2_0_12), float(k2_0_21), float(k2_0_30)],
+            )
 
         else:  # Split flap
             k1_0_12 = (
@@ -347,9 +351,11 @@ class ComputeDeltaHighLift(FigureDigitization):
             k1_0_30 = (
                 -0.000 * chord_ratio**3 + 4.694 * chord_ratio**2 + 4.372 * chord_ratio - 0.0031
             )
-            flap_chord_contribution = interpolate.interp1d(
-                [0.12, 0.21, 0.30], [float(k1_0_12), float(k1_0_21), float(k1_0_30)]
-            )(np.clip(thickness_ratio, 0.12, 0.30))
+            flap_chord_contribution = np.interp(
+                np.clip(thickness_ratio, 0.12, 0.30),
+                [0.12, 0.21, 0.30],
+                [float(k1_0_12), float(k1_0_21), float(k1_0_30)],
+            )
             k2_0_12 = (
                 -4.161e-7 * flap_angle**3
                 + 5.5496e-5 * flap_angle**2
@@ -368,9 +374,11 @@ class ComputeDeltaHighLift(FigureDigitization):
                 - 1.2443e-4 * flap_angle
                 + 5.1647e-4
             )
-            flap_deflection_contribution = interpolate.interp1d(
-                [0.12, 0.21, 0.30], [float(k2_0_12), float(k2_0_21), float(k2_0_30)]
-            )(np.clip(thickness_ratio, 0.12, 0.30))
+            flap_deflection_contribution = np.interp(
+                np.clip(thickness_ratio, 0.12, 0.30),
+                [0.12, 0.21, 0.30],
+                [float(k2_0_12), float(k2_0_21), float(k2_0_30)],
+            )
         delta_cd_flaps = flap_chord_contribution * flap_deflection_contribution * area_ratio
 
         return delta_cd_flaps

--- a/src/fastga/models/aerodynamics/components/hinge_moments_elevator.py
+++ b/src/fastga/models/aerodynamics/components/hinge_moments_elevator.py
@@ -14,7 +14,6 @@
 
 import numpy as np
 import openmdao.api as om
-import scipy.interpolate as inter
 
 import fastoad.api as oad
 from stdatm import Atmosphere
@@ -147,8 +146,7 @@ class Compute2DHingeMomentsTail(FigureDigitization):
         elif balance_ratio > 0.5:
             balance_ratio = 0.5
 
-        k_ch_alpha_balance_inter = inter.interp1d([0.15, 0.50], [0.93, 0.2])
-        k_ch_alpha_balance = k_ch_alpha_balance_inter(balance_ratio)
+        k_ch_alpha_balance = np.interp(balance_ratio, [0.15, 0.50], [0.93, 0.2])
 
         ch_alpha_balance = k_ch_alpha_balance * ch_prime_prime_alpha
 
@@ -196,7 +194,7 @@ class Compute2DHingeMomentsTail(FigureDigitization):
 
         # Step 4. Same assumption as the step 4. of the previous section. Only this time we only
         # take the curve for the NACA 0009
-        k_ch_delta_balance = inter.interp1d([0.15, 0.50], [0.93, 0.2])(balance_ratio)
+        k_ch_delta_balance = np.interp(balance_ratio, [0.15, 0.50], [0.93, 0.2])
 
         ch_delta_balance = k_ch_delta_balance * ch_prime_prime_delta
 

--- a/src/fastga/models/aerodynamics/components/vt/compute_cl_alpha_vt.py
+++ b/src/fastga/models/aerodynamics/components/vt/compute_cl_alpha_vt.py
@@ -13,7 +13,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-import scipy.interpolate as interp
 import fastoad.api as oad
 
 from ..figure_digitization import FigureDigitization
@@ -94,7 +93,7 @@ class ComputeClAlphaVerticalTail(FigureDigitization):
         if span_vt / avg_fus_depth < 2.0:
             kv = 0.75
         elif span_vt / avg_fus_depth < 3.5:
-            kv = interp.interp1d([2.0, 3.5], [0.75, 1.0])(float(span_vt / avg_fus_depth))
+            kv = np.interp(float(span_vt / avg_fus_depth), [2.0, 3.5], [0.75, 1.0])
         else:
             kv = 1.0
 

--- a/src/fastga/models/geometry/profiles/profile.py
+++ b/src/fastga/models/geometry/profiles/profile.py
@@ -18,7 +18,6 @@ from typing import Sequence, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy.interpolate import CubicSpline
 
 Coordinates2D = namedtuple("Coordinates2D", ["x", "y"])
 
@@ -164,10 +163,11 @@ class Profile:
             0.1 - max(min(x_up_vect), min(x_lo_vect))
         ) + max(min(x_up_vect), min(x_lo_vect))
         x_interp = np.append(x_start, np.linspace(0.13, min(max(x_up_vect), max(x_lo_vect)), 25))
-        interp_lower = CubicSpline(lower_side_points[X], lower_side_points[Z])
-        interp_upper = CubicSpline(upper_side_points[X], upper_side_points[Z])
         z_sides = pd.DataFrame(
-            {"z_lower": interp_lower(x_interp), "z_upper": interp_upper(x_interp)}
+            {
+                "z_lower": np.interp(x_interp, lower_side_points[X], lower_side_points[Z]),
+                "z_upper": np.interp(x_interp, upper_side_points[X], upper_side_points[Z]),
+            }
         )
         z = z_sides.mean(axis=1)
         thickness = z_sides.diff(axis=1).iloc[:, -1]

--- a/src/fastga/models/geometry/profiles/profile.py
+++ b/src/fastga/models/geometry/profiles/profile.py
@@ -18,7 +18,7 @@ from typing import Sequence, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy.interpolate import interp1d
+from scipy.interpolate import CubicSpline
 
 Coordinates2D = namedtuple("Coordinates2D", ["x", "y"])
 
@@ -164,8 +164,8 @@ class Profile:
             0.1 - max(min(x_up_vect), min(x_lo_vect))
         ) + max(min(x_up_vect), min(x_lo_vect))
         x_interp = np.append(x_start, np.linspace(0.13, min(max(x_up_vect), max(x_lo_vect)), 25))
-        interp_lower = interp1d(lower_side_points[X], lower_side_points[Z], kind="slinear")
-        interp_upper = interp1d(upper_side_points[X], upper_side_points[Z], kind="slinear")
+        interp_lower = CubicSpline(lower_side_points[X], lower_side_points[Z])
+        interp_upper = CubicSpline(upper_side_points[X], upper_side_points[Z])
         z_sides = pd.DataFrame(
             {"z_lower": interp_lower(x_interp), "z_upper": interp_upper(x_interp)}
         )

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
@@ -171,7 +171,11 @@ class aircraft_equilibrium_limit(om.ExplicitComponent):
         )
 
         stall_angle_inter = RectBivariateSpline(
-            elevator_chord_ratio_list, elevator_deflection_list, stall_angle_reduction_list.T, kx=1, ky=1
+            elevator_chord_ratio_list,
+            elevator_deflection_list,
+            stall_angle_reduction_list.T,
+            kx=1,
+            ky=1,
         )
         stall_angle_reduction = stall_angle_inter(elevator_chord_ratio, elevator_deflection)[0, 0]
 

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
@@ -153,18 +153,22 @@ class aircraft_equilibrium_limit(om.ExplicitComponent):
         cl_alpha_isolated_htp = inputs["data:aerodynamics:horizontal_tail:low_speed:CL_alpha"]
         cl_alpha_htp = inputs["data:aerodynamics:horizontal_tail:low_speed:CL_alpha_isolated"]
 
-        elevator_chord_ratio_list = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0])
+        elevator_chord_ratio_list = np.array(
+            [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+        )
         elevator_deflection_list = np.array([0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0])
 
-        stall_angle_reduction_list = np.array([
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.3, 0.5, 1.1, 1.6, 2.2, 2.7, 3.3, 3.9, 4.4, 5.0],
-            [0.0, 0.6, 1.0, 2.1, 3.2, 4.4, 5.5, 6.6, 7.7, 8.9, 10.0],
-            [0.0, 0.9, 1.5, 3.2, 4.9, 6.5, 8.2, 9.9, 11.6, 13.3, 15.0],
-            [0.0, 1.2, 2.0, 4.2, 6.5, 8.7, 11.0, 13.2, 15.5, 17.7, 20.0],
-            [0.0, 1.6, 2.5, 5.3, 8.1, 11.0, 13.7, 16.5, 19.4, 22.2, 25.0],
-            [0.0, 1.9, 3.0, 6.4, 9.7, 13.1, 16.5, 19.9, 23.2, 26.6, 30.0],
-        ])
+        stall_angle_reduction_list = np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.3, 0.5, 1.1, 1.6, 2.2, 2.7, 3.3, 3.9, 4.4, 5.0],
+                [0.0, 0.6, 1.0, 2.1, 3.2, 4.4, 5.5, 6.6, 7.7, 8.9, 10.0],
+                [0.0, 0.9, 1.5, 3.2, 4.9, 6.5, 8.2, 9.9, 11.6, 13.3, 15.0],
+                [0.0, 1.2, 2.0, 4.2, 6.5, 8.7, 11.0, 13.2, 15.5, 17.7, 20.0],
+                [0.0, 1.6, 2.5, 5.3, 8.1, 11.0, 13.7, 16.5, 19.4, 22.2, 25.0],
+                [0.0, 1.9, 3.0, 6.4, 9.7, 13.1, 16.5, 19.9, 23.2, 26.6, 30.0],
+            ]
+        )
 
         stall_angle_inter = RectBivariateSpline(
             elevator_chord_ratio_list, elevator_deflection_list, stall_angle_reduction_list.T

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
@@ -171,9 +171,9 @@ class aircraft_equilibrium_limit(om.ExplicitComponent):
         )
 
         stall_angle_inter = RectBivariateSpline(
-            elevator_chord_ratio_list, elevator_deflection_list, stall_angle_reduction_list.T
+            elevator_chord_ratio_list, elevator_deflection_list, stall_angle_reduction_list.T, kx=1, ky=1
         )
-        stall_angle_reduction = stall_angle_inter(elevator_chord_ratio, elevator_deflection)
+        stall_angle_reduction = stall_angle_inter(elevator_chord_ratio, elevator_deflection)[0, 0]
 
         stall_angle_reduction_wrt_aircraft = (
             cl_alpha_isolated_htp / cl_alpha_htp * stall_angle_reduction

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
@@ -16,7 +16,7 @@ proposed by Gudmundsson.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-import scipy.interpolate as inter
+from scipy.interpolate import RectBivariateSpline
 from scipy.constants import g
 import openmdao.api as om
 
@@ -153,10 +153,10 @@ class aircraft_equilibrium_limit(om.ExplicitComponent):
         cl_alpha_isolated_htp = inputs["data:aerodynamics:horizontal_tail:low_speed:CL_alpha"]
         cl_alpha_htp = inputs["data:aerodynamics:horizontal_tail:low_speed:CL_alpha_isolated"]
 
-        elevator_chord_ratio_list = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-        elevator_deflection_list = [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0]
+        elevator_chord_ratio_list = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0])
+        elevator_deflection_list = np.array([0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0])
 
-        stall_angle_reduction_list = [
+        stall_angle_reduction_list = np.array([
             [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             [0.0, 0.3, 0.5, 1.1, 1.6, 2.2, 2.7, 3.3, 3.9, 4.4, 5.0],
             [0.0, 0.6, 1.0, 2.1, 3.2, 4.4, 5.5, 6.6, 7.7, 8.9, 10.0],
@@ -164,10 +164,10 @@ class aircraft_equilibrium_limit(om.ExplicitComponent):
             [0.0, 1.2, 2.0, 4.2, 6.5, 8.7, 11.0, 13.2, 15.5, 17.7, 20.0],
             [0.0, 1.6, 2.5, 5.3, 8.1, 11.0, 13.7, 16.5, 19.4, 22.2, 25.0],
             [0.0, 1.9, 3.0, 6.4, 9.7, 13.1, 16.5, 19.9, 23.2, 26.6, 30.0],
-        ]
+        ])
 
-        stall_angle_inter = inter.interp2d(
-            elevator_chord_ratio_list, elevator_deflection_list, stall_angle_reduction_list
+        stall_angle_inter = RectBivariateSpline(
+            elevator_chord_ratio_list, elevator_deflection_list, stall_angle_reduction_list.T
         )
         stall_angle_reduction = stall_angle_inter(elevator_chord_ratio, elevator_deflection)
 

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -19,7 +19,6 @@ import numpy as np
 import openmdao.api as om
 
 from scipy.constants import g
-from scipy.interpolate import interp1d
 
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
@@ -138,8 +137,8 @@ class ComputeClimb(DynamicEquilibrium):
                 name="sizing:main_route:climb",
             )
 
-            climb_rate = interp1d([0.0, float(cruise_altitude)], [climb_rate_sl, climb_rate_cl])(
-                altitude_t
+            climb_rate = np.interp(
+                altitude_t, [0.0, float(cruise_altitude)], [climb_rate_sl, climb_rate_cl]
             )
 
             self.complete_flight_point(flight_point, v_cas=v_cas, climb_rate=climb_rate)

--- a/src/fastga/models/propulsion/fuel_propulsion/basicTurbo_prop/basicTP_engine.py
+++ b/src/fastga/models/propulsion/fuel_propulsion/basicTurbo_prop/basicTP_engine.py
@@ -16,7 +16,7 @@
 import logging
 from collections import OrderedDict
 from typing import Union, Sequence, Tuple, Optional
-from scipy.interpolate import interp1d, RectBivariateSpline
+from scipy.interpolate import RectBivariateSpline
 import numpy as np
 
 import openmdao.api as om
@@ -1431,7 +1431,7 @@ class BasicTPEngine(AbstractFuelPropulsion):
         # Compute engine dimensions
         if max_thermal_power_in_kw < 850.0:
             self.engine.height = (
-                interp1d([500.0, 850.0], [21.0, 25.0])(max_thermal_power_in_kw) * 0.0254
+                np.interp(max_thermal_power_in_kw, [500.0, 850.0], [21.0, 25.0]) * 0.0254
             )
             self.engine.width = 21.5 * 0.0254
         else:

--- a/src/fastga/models/propulsion/fuel_propulsion/basicTurbo_prop/turboprop_components/propeller_thrust.py
+++ b/src/fastga/models/propulsion/fuel_propulsion/basicTurbo_prop/turboprop_components/propeller_thrust.py
@@ -1,6 +1,6 @@
 import numpy as np
 import openmdao.api as om
-from scipy.interpolate import RectBivariateSpline, interp1d
+from scipy.interpolate import RectBivariateSpline, CubicSpline
 from stdatm import Atmosphere
 
 THRUST_PTS_NB = 30
@@ -235,12 +235,8 @@ class PropellerMaxThrust(om.ExplicitComponent):
         thrust_limit_cl = inputs["data:aerodynamics:propeller:cruise_level:thrust_limit"]
         speed_cl = inputs["data:aerodynamics:propeller:cruise_level:speed"]
 
-        propeller_max_thrust_sl_func = interp1d(
-            speed_sl, thrust_limit_sl, kind="cubic", bounds_error=False, fill_value="extrapolate"
-        )
-        propeller_max_thrust_cl_func = interp1d(
-            speed_cl, thrust_limit_cl, kind="cubic", bounds_error=False, fill_value="extrapolate"
-        )
+        propeller_max_thrust_sl_func = CubicSpline(speed_sl, thrust_limit_sl)
+        propeller_max_thrust_cl_func = CubicSpline(speed_cl, thrust_limit_cl)
 
         lower_bound_thrust_limit = propeller_max_thrust_sl_func(
             true_airspeed

--- a/src/fastga/models/propulsion/fuel_propulsion/basicTurbo_prop_map/basicTP_engine_mapped.py
+++ b/src/fastga/models/propulsion/fuel_propulsion/basicTurbo_prop_map/basicTP_engine_mapped.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Union, Sequence, Tuple, Optional
 import numpy as np
-from scipy.interpolate import interp1d, LinearNDInterpolator
+from scipy.interpolate import LinearNDInterpolator
 
 import fastoad.api as oad
 from fastoad.constants import EngineSetting
@@ -509,40 +509,47 @@ class BasicTPEngineMapped(AbstractFuelPropulsion):
         if altitude > self.intermediate_altitude:
             mach_il = np.clip(atmosphere.mach, min(self.turbo_mach_IL), max(self.turbo_mach_IL))
             mach_cl = np.clip(atmosphere.mach, min(self.turbo_mach_CL), max(self.turbo_mach_CL))
-            max_thrust_interp_IL = interp1d(self.turbo_mach_IL, self.turbo_thrust_max_IL)
-            max_thrust_interp_CL = interp1d(self.turbo_mach_CL, self.turbo_thrust_max_CL)
             thrust_interp_IL = np.clip(
-                thrust, min(self.turbo_thrust_IL), max_thrust_interp_IL(mach_il)
+                thrust,
+                min(self.turbo_thrust_IL),
+                np.interp(mach_il, self.turbo_mach_IL, self.turbo_thrust_max_IL),
             )
             thrust_interp_CL = np.clip(
-                thrust, min(self.turbo_thrust_CL), max_thrust_interp_CL(mach_cl)
+                thrust,
+                min(self.turbo_thrust_CL),
+                np.interp(mach_cl, self.turbo_mach_CL, self.turbo_thrust_max_CL),
             )
             # lower_bound = float(sfc_interp_IL(thrust_interp_IL, mach_il))
             lower_bound = float(self.sfc_interpolator_il((thrust_interp_IL, mach_il)))
             # upper_bound = float(sfc_interp_CL(thrust_interp_CL, mach_cl))
             upper_bound = float(self.sfc_interpolator_cl((thrust_interp_CL, mach_cl)))
             sfc = float(
-                interp1d(
+                np.interp(
+                    max(float(altitude), 0.0),
                     [self.intermediate_altitude, self.cruise_altitude_propeller],
                     [lower_bound, upper_bound],
-                )(max(float(altitude), 0.0))
+                )
             )
         else:
             mach_sl = np.clip(atmosphere.mach, min(self.turbo_mach_SL), max(self.turbo_mach_SL))
             mach_il = np.clip(atmosphere.mach, min(self.turbo_mach_IL), max(self.turbo_mach_IL))
-            max_thrust_interp_SL = interp1d(self.turbo_mach_SL, self.turbo_thrust_max_SL)
-            max_thrust_interp_IL = interp1d(self.turbo_mach_IL, self.turbo_thrust_max_IL)
             thrust_interp_SL = np.clip(
-                thrust, min(self.turbo_thrust_SL), max_thrust_interp_SL(mach_sl)
+                thrust,
+                min(self.turbo_thrust_SL),
+                np.interp(mach_sl, self.turbo_mach_SL, self.turbo_thrust_max_SL),
             )
             thrust_interp_IL = np.clip(
-                thrust, min(self.turbo_thrust_IL), max_thrust_interp_IL(mach_il)
+                thrust,
+                min(self.turbo_thrust_IL),
+                np.interp(mach_il, self.turbo_mach_IL, self.turbo_thrust_max_IL),
             )
             lower_bound = float(self.sfc_interpolator_sl((thrust_interp_SL, mach_sl)))
             upper_bound = float(self.sfc_interpolator_il((thrust_interp_IL, mach_il)))
             sfc = float(
-                interp1d([0.0, self.intermediate_altitude], [lower_bound, upper_bound])(
-                    max(float(altitude), 0.0)
+                np.interp(
+                    max(float(altitude), 0.0),
+                    [0.0, self.intermediate_altitude],
+                    [lower_bound, upper_bound],
                 )
             )
 
@@ -603,40 +610,47 @@ class BasicTPEngineMapped(AbstractFuelPropulsion):
 
     def _max_thrust(self, altitude: float, mach: float) -> float:
         if altitude > self.intermediate_altitude:
-            max_thrust_interp_IL = interp1d(self.turbo_mach_IL, self.turbo_thrust_max_IL)
-            max_thrust_interp_CL = interp1d(self.turbo_mach_CL, self.turbo_thrust_max_CL)
             max_thrust_IL = float(
-                max_thrust_interp_IL(
-                    np.clip(mach, min(self.turbo_mach_IL), max(self.turbo_mach_IL))
+                np.interp(
+                    np.clip(mach, min(self.turbo_mach_IL), max(self.turbo_mach_IL)),
+                    self.turbo_mach_IL,
+                    self.turbo_thrust_max_IL,
                 )
             )
             max_thrust_CL = float(
-                max_thrust_interp_CL(
-                    np.clip(mach, min(self.turbo_mach_CL), max(self.turbo_mach_CL))
+                np.interp(
+                    np.clip(mach, min(self.turbo_mach_CL), max(self.turbo_mach_CL)),
+                    self.turbo_mach_CL,
+                    self.turbo_thrust_max_CL,
                 )
             )
             max_thrust = float(
-                interp1d(
+                np.interp(
+                    max(float(altitude), 0.0),
                     [self.intermediate_altitude, self.cruise_altitude_propeller],
                     [max_thrust_IL, max_thrust_CL],
-                )(max(float(altitude), 0.0))
+                )
             )
         else:
-            max_thrust_interp_SL = interp1d(self.turbo_mach_SL, self.turbo_thrust_max_SL)
-            max_thrust_interp_IL = interp1d(self.turbo_mach_IL, self.turbo_thrust_max_IL)
             max_thrust_SL = float(
-                max_thrust_interp_SL(
-                    np.clip(mach, min(self.turbo_mach_SL), max(self.turbo_mach_SL))
+                np.interp(
+                    np.clip(mach, min(self.turbo_mach_SL), max(self.turbo_mach_SL)),
+                    self.turbo_mach_SL,
+                    self.turbo_thrust_max_SL,
                 )
             )
             max_thrust_IL = float(
-                max_thrust_interp_IL(
-                    np.clip(mach, min(self.turbo_mach_IL), max(self.turbo_mach_IL))
+                np.interp(
+                    np.clip(mach, min(self.turbo_mach_IL), max(self.turbo_mach_IL)),
+                    self.turbo_mach_IL,
+                    self.turbo_thrust_max_IL,
                 )
             )
             max_thrust = float(
-                interp1d([0.0, self.intermediate_altitude], [max_thrust_SL, max_thrust_IL])(
-                    max(float(altitude), 0.0)
+                np.interp(
+                    max(float(altitude), 0.0),
+                    [0.0, self.intermediate_altitude],
+                    [max_thrust_SL, max_thrust_IL],
                 )
             )
 

--- a/src/fastga/models/weight/mass_breakdown/a_airframe/wing_components/compute_skin_mass.py
+++ b/src/fastga/models/weight/mass_breakdown/a_airframe/wing_components/compute_skin_mass.py
@@ -17,7 +17,7 @@ in her MAE research project report.
 
 import numpy as np
 import openmdao.api as om
-from scipy.interpolate import CubicSpline
+from scipy.interpolate import make_interp_spline
 from stdatm import Atmosphere
 
 
@@ -131,7 +131,7 @@ class ComputeSkinMass(om.ExplicitComponent):
         for mach in mach_interp:
             v_interp.append(float(mach * atm.speed_of_sound))
         cl_alpha_interp = inputs["data:aerodynamics:aircraft:mach_interpolation:CL_alpha_vector"]
-        cl_alpha_fct = CubicSpline(v_interp, cl_alpha_interp)
+        cl_alpha_fct = make_interp_spline(v_interp, cl_alpha_interp, k=2)
 
         cl_alpha_ac = cl_alpha_fct(atm.true_airspeed)
 

--- a/src/fastga/models/weight/mass_breakdown/a_airframe/wing_components/compute_skin_mass.py
+++ b/src/fastga/models/weight/mass_breakdown/a_airframe/wing_components/compute_skin_mass.py
@@ -17,7 +17,7 @@ in her MAE research project report.
 
 import numpy as np
 import openmdao.api as om
-from scipy.interpolate import interp1d
+from scipy.interpolate import CubicSpline
 from stdatm import Atmosphere
 
 
@@ -131,9 +131,7 @@ class ComputeSkinMass(om.ExplicitComponent):
         for mach in mach_interp:
             v_interp.append(float(mach * atm.speed_of_sound))
         cl_alpha_interp = inputs["data:aerodynamics:aircraft:mach_interpolation:CL_alpha_vector"]
-        cl_alpha_fct = interp1d(
-            v_interp, cl_alpha_interp, fill_value="extrapolate", kind="quadratic"
-        )
+        cl_alpha_fct = CubicSpline(v_interp, cl_alpha_interp)
 
         cl_alpha_ac = cl_alpha_fct(atm.true_airspeed)
 


### PR DESCRIPTION
Scipy's interp1d and inter2d functions were considered "legacy" (i.e., not supported anymore). This PR replaces their use with the recommended alternatives in https://docs.scipy.org/doc/scipy/tutorial/interpolate/interp_transition_guide.html#interp-transition-guide and https://docs.scipy.org/doc/scipy/tutorial/interpolate/1D.html#recommended-replacements-for-interp1d-modes