### PR TITLE
Replace constant CSV I/O actions in OpenVSP with caching

### DIFF
--- a/src/fastga/models/aerodynamics/__init__.py
+++ b/src/fastga/models/aerodynamics/__init__.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
@@ -118,6 +118,7 @@ class AerodynamicsHighSpeed(Group):
                         low_speed_aero=False,
                         compute_mach_interpolation=True,
                         result_folder_path=self.options["result_folder_path"],
+                        result_file_name=self.options["result_file_name"],
                         openvsp_exe_path=self.options["openvsp_exe_path"],
                         airfoil_folder_path=self.options["airfoil_folder_path"],
                         wing_airfoil_file=self.options["wing_airfoil"],
@@ -133,6 +134,7 @@ class AerodynamicsHighSpeed(Group):
                         low_speed_aero=False,
                         compute_mach_interpolation=False,
                         result_folder_path=self.options["result_folder_path"],
+                        result_file_name=self.options["result_file_name"],
                         airfoil_folder_path=self.options["airfoil_folder_path"],
                         openvsp_exe_path=self.options["openvsp_exe_path"],
                         wing_airfoil_file=self.options["wing_airfoil"],
@@ -225,6 +227,7 @@ class AerodynamicsHighSpeed(Group):
                 ComputeSlipstreamOpenvspSubGroup(
                     propulsion_id=self.options["propulsion_id"],
                     result_folder_path=self.options["result_folder_path"],
+                    result_file_name=self.options["result_file_name"],
                     airfoil_folder_path=self.options["airfoil_folder_path"],
                     openvsp_exe_path=self.options["openvsp_exe_path"],
                     wing_airfoil_file=self.options["wing_airfoil"],

--- a/src/fastga/models/aerodynamics/aerodynamics_low_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_low_speed.py
@@ -92,6 +92,7 @@ class AerodynamicsLowSpeed(om.Group):
                     compute_mach_interpolation=False,
                     result_folder_path=self.options["result_folder_path"],
                     openvsp_exe_path=self.options["openvsp_exe_path"],
+                    result_file_name=self.options["result_file_name"],
                     airfoil_folder_path=self.options["airfoil_folder_path"],
                     wing_airfoil_file=self.options["wing_airfoil"],
                     htp_airfoil_file=self.options["htp_airfoil"],
@@ -214,6 +215,7 @@ class AerodynamicsLowSpeed(om.Group):
                 ComputeSlipstreamOpenvspSubGroup(
                     propulsion_id=self.options["propulsion_id"],
                     result_folder_path=self.options["result_folder_path"],
+                    result_file_name=self.options["result_file_name"],
                     airfoil_folder_path=self.options["airfoil_folder_path"],
                     openvsp_exe_path=self.options["openvsp_exe_path"],
                     wing_airfoil_file=self.options["wing_airfoil"],

--- a/src/fastga/models/aerodynamics/constants.py
+++ b/src/fastga/models/aerodynamics/constants.py
@@ -26,6 +26,37 @@ _DEFAULT_AIRFOIL_FILE = "naca23012.af"
 DEFAULT_2D_CL_MAX = 1.9
 DEFAULT_2D_CL_MIN = -1.7
 
+GEOMETRY_SET_LABELS = [
+    "sweep25_wing",
+    "taper_ratio_wing",
+    "aspect_ratio_wing",
+    "dihedral_angle_wing",
+    "twist_angle_wing",
+    "sweep25_htp",
+    "taper_ratio_htp",
+    "aspect_ratio_htp",
+]
+
+RESULT_LABELS = [
+    "cl_0_wing",
+    "cl_X_wing",
+    "cl_alpha_wing",
+    "cm_0_wing",
+    "y_vector_wing",
+    "cl_vector_wing",
+    "chord_vector_wing",
+    "coef_k_wing",
+    "cl_0_htp",
+    "cl_X_htp",
+    "cl_alpha_htp",
+    "cl_alpha_htp_isolated",
+    "y_vector_htp",
+    "cl_vector_htp",
+    "coef_k_htp",
+    "saved_ref_area",
+    "area_ratio",
+]
+
 SUBMODEL_CD0 = "submodel.aerodynamics.aircraft.cd0"
 SUBMODEL_CD0_WING = "submodel.aerodynamics.wing.cd0"
 SUBMODEL_CD0_FUSELAGE = "submodel.aerodynamics.fuselage.cd0"

--- a/src/fastga/models/aerodynamics/constants.py
+++ b/src/fastga/models/aerodynamics/constants.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2025  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -45,14 +45,14 @@ RESULT_LABELS = [
     "y_vector_wing",
     "cl_vector_wing",
     "chord_vector_wing",
-    "coef_k_wing",
+    "coeff_k_wing",
     "cl_0_htp",
     "cl_X_htp",
     "cl_alpha_htp",
     "cl_alpha_htp_isolated",
     "y_vector_htp",
     "cl_vector_htp",
-    "coef_k_htp",
+    "coeff_k_htp",
     "saved_ref_area",
     "area_ratio",
 ]

--- a/src/fastga/models/aerodynamics/external/__init__.py
+++ b/src/fastga/models/aerodynamics/external/__init__.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/external/openvsp/__init__.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/__init__.py
@@ -1,6 +1,6 @@
 """Module for OpenMDAO-embedded XFOIL"""
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
@@ -166,14 +166,14 @@ class _ComputeAeroOpenVSP(OpenVSPSimpleGeometry):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
             cl_0_htp,
             cl_X_htp,
             cl_alpha_htp,
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coef_k_htp,
+            coeff_k_htp,
             _,
         ) = self.compute_aero_coeff(inputs, outputs, altitude, mach, input_aoa)
 
@@ -195,7 +195,7 @@ class _ComputeAeroOpenVSP(OpenVSPSimpleGeometry):
             outputs["data:aerodynamics:wing:low_speed:Y_vector"] = y_vector_wing
             outputs["data:aerodynamics:wing:low_speed:CL_vector"] = cl_vector_wing
             outputs["data:aerodynamics:wing:low_speed:chord_vector"] = chord_vector_wing
-            outputs["data:aerodynamics:wing:low_speed:induced_drag_coefficient"] = coef_k_wing
+            outputs["data:aerodynamics:wing:low_speed:induced_drag_coefficient"] = coeff_k_wing
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL0"] = cl_0_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL_ref"] = cl_X_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL_alpha"] = cl_alpha_htp
@@ -205,19 +205,19 @@ class _ComputeAeroOpenVSP(OpenVSPSimpleGeometry):
             outputs["data:aerodynamics:horizontal_tail:low_speed:Y_vector"] = y_vector_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL_vector"] = cl_vector_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:induced_drag_coefficient"] = (
-                coef_k_htp
+                coeff_k_htp
             )
         else:
             outputs["data:aerodynamics:wing:cruise:CL0_clean"] = cl_0_wing
             outputs["data:aerodynamics:wing:cruise:CL_ref"] = cl_ref_wing
             outputs["data:aerodynamics:wing:cruise:CL_alpha"] = cl_alpha_wing
             outputs["data:aerodynamics:wing:cruise:CM0_clean"] = cm_0_wing
-            outputs["data:aerodynamics:wing:cruise:induced_drag_coefficient"] = coef_k_wing
+            outputs["data:aerodynamics:wing:cruise:induced_drag_coefficient"] = coeff_k_wing
             outputs["data:aerodynamics:horizontal_tail:cruise:CL0"] = cl_0_htp
             outputs["data:aerodynamics:horizontal_tail:cruise:CL_alpha"] = cl_alpha_htp
             outputs["data:aerodynamics:horizontal_tail:cruise:CL_alpha_isolated"] = (
                 cl_alpha_htp_isolated
             )
             outputs["data:aerodynamics:horizontal_tail:cruise:induced_drag_coefficient"] = (
-                coef_k_htp
+                coeff_k_htp
             )

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
@@ -31,6 +31,13 @@ class ComputeAeroOpenVSP(Group):
         self.options.declare("low_speed_aero", default=False, types=bool)
         self.options.declare("compute_mach_interpolation", default=False, types=bool)
         self.options.declare("result_folder_path", default="", types=str)
+        self.options.declare(
+            "result_file_name",
+            default="",
+            types=str,
+            desc="Name of the file to store the results cache as a JSON file. If not set, "
+            "the cache will not be saved to disk.",
+        )
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
         self.options.declare(
@@ -53,6 +60,7 @@ class ComputeAeroOpenVSP(Group):
                 low_speed_aero=self.options["low_speed_aero"],
                 compute_mach_interpolation=self.options["compute_mach_interpolation"],
                 result_folder_path=self.options["result_folder_path"],
+                result_file_name=self.options["result_file_name"],
                 openvsp_exe_path=self.options["openvsp_exe_path"],
                 airfoil_folder_path=self.options["airfoil_folder_path"],
                 wing_airfoil_file=self.options["wing_airfoil_file"],

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
@@ -2,7 +2,7 @@
 Estimation of aero coefficients using OPENVSP.
 """
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -2,7 +2,7 @@
 Estimation of slipstream effects using OPENVSP.
 """
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -45,6 +45,13 @@ class ComputeSlipstreamOpenvsp(om.Group):
         self.options.declare("low_speed_aero", default=False, types=bool)
         self.options.declare("propulsion_id", default="", types=str)
         self.options.declare("result_folder_path", default="", types=str)
+        self.options.declare(
+            "result_file_name",
+            default="",
+            types=str,
+            desc="Name of the file to store the results cache as a JSON file. If not set, "
+            "the cache will not be saved to disk.",
+        )
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
         self.options.declare(
@@ -62,6 +69,7 @@ class ComputeSlipstreamOpenvsp(om.Group):
             ComputeSlipstreamOpenvspSubGroup(
                 propulsion_id=self.options["propulsion_id"],
                 result_folder_path=self.options["result_folder_path"],
+                result_file_name=self.options["result_file_name"],
                 openvsp_exe_path=self.options["openvsp_exe_path"],
                 airfoil_folder_path=self.options["airfoil_folder_path"],
                 wing_airfoil_file=self.options["wing_airfoil_file"],
@@ -83,6 +91,13 @@ class ComputeSlipstreamOpenvspSubGroup(om.Group):
         self.options.declare("low_speed_aero", default=False, types=bool)
         self.options.declare("propulsion_id", default="", types=str)
         self.options.declare("result_folder_path", default="", types=str)
+        self.options.declare(
+            "result_file_name",
+            default="",
+            types=str,
+            desc="Name of the file to store the results cache as a JSON file. If not set, "
+            "the cache will not be saved to disk.",
+        )
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
         self.options.declare(
@@ -115,6 +130,7 @@ class ComputeSlipstreamOpenvspSubGroup(om.Group):
             _ComputeSlipstreamOpenvsp(
                 propulsion_id=self.options["propulsion_id"],
                 result_folder_path=self.options["result_folder_path"],
+                result_file_name=self.options["result_file_name"],
                 openvsp_exe_path=self.options["openvsp_exe_path"],
                 airfoil_folder_path=self.options["airfoil_folder_path"],
                 wing_airfoil_file=self.options["wing_airfoil_file"],
@@ -228,12 +244,16 @@ class _ComputeSlipstreamOpenvsp(OpenVSPSimpleGeometryDP):
         # will appear, this is taken as the angle for which the clean wing is at its max angle of
         # attack
 
-        alpha_max = (cl_max_clean - cl0) / cl_alpha
+        alpha_max = round(float((cl_max_clean - cl0) / cl_alpha), 2)
+        thrust = round(float(inputs["thrust"]), 1)
+        shaft_power = round(float(inputs["shaft_power"]), 1)
 
         wing_rotor = self.compute_wing_rotor(
-            inputs, outputs, altitude, mach, alpha_max, inputs["thrust"], inputs["shaft_power"]
+            inputs, outputs, altitude, mach, alpha_max, thrust, shaft_power
         )
-        wing = self.compute_aero(inputs, outputs, altitude, mach, alpha_max, comp_opt="wing")
+        wing = self.compute_aero(
+            inputs, outputs, altitude, mach, alpha_max, comp_opt="wing", use_cache=True
+        )
 
         cl_vector_prop_on = wing_rotor["cl_vector"]
         y_vector_prop_on = wing_rotor["y_vector"]

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -263,46 +263,48 @@ class _ComputeSlipstreamOpenvsp(OpenVSPSimpleGeometryDP):
         y_vector_prop_off = wing["y_vector"]
 
         additional_zeros = list(np.zeros(SPAN_MESH_POINT - len(cl_vector_prop_on)))
-        cl_vector_prop_on.extend(additional_zeros)
-        y_vector_prop_on.extend(additional_zeros)
-        cl_vector_prop_off.extend(additional_zeros)
-        y_vector_prop_off.extend(additional_zeros)
+        cl_vector_prop_on_extended = cl_vector_prop_on + additional_zeros
+        y_vector_prop_on_extended = y_vector_prop_on + additional_zeros
+        cl_vector_prop_off_extended = cl_vector_prop_off + additional_zeros
+        y_vector_prop_off_extended = y_vector_prop_off + additional_zeros
 
         cl_diff = np.round(
-            np.asarray(cl_vector_prop_on) - np.asarray(cl_vector_prop_off), 4
+            np.asarray(cl_vector_prop_on_extended) - np.asarray(cl_vector_prop_off_extended), 4
         ).tolist()
 
         if self.options["low_speed_aero"]:
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_on:Y_vector"] = (
-                y_vector_prop_on
+                y_vector_prop_on_extended
             )
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_on:CL_vector"] = (
-                cl_vector_prop_on
+                cl_vector_prop_on_extended
             )
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_on:CT_ref"] = wing_rotor["ct"]
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_on:CL"] = wing_rotor["cl"]
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_on:velocity"] = velocity
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_off:Y_vector"] = (
-                y_vector_prop_off
+                y_vector_prop_off_extended
             )
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_off:CL_vector"] = (
-                cl_vector_prop_off
+                cl_vector_prop_off_extended
             )
             outputs["data:aerodynamics:slipstream:wing:low_speed:prop_off:CL"] = wing["cl"]
             outputs["data:aerodynamics:slipstream:wing:low_speed:only_prop:CL_vector"] = cl_diff
         else:
-            outputs["data:aerodynamics:slipstream:wing:cruise:prop_on:Y_vector"] = y_vector_prop_on
+            outputs["data:aerodynamics:slipstream:wing:cruise:prop_on:Y_vector"] = (
+                y_vector_prop_on_extended
+            )
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_on:CL_vector"] = (
-                cl_vector_prop_on
+                cl_vector_prop_on_extended
             )
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_on:CT_ref"] = wing_rotor["ct"]
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_on:CL"] = wing_rotor["cl"]
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_on:velocity"] = velocity
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_off:Y_vector"] = (
-                y_vector_prop_off
+                y_vector_prop_off_extended
             )
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_off:CL_vector"] = (
-                cl_vector_prop_off
+                cl_vector_prop_off_extended
             )
             outputs["data:aerodynamics:slipstream:wing:cruise:prop_off:CL"] = wing["cl"]
             outputs["data:aerodynamics:slipstream:wing:cruise:only_prop:CL_vector"] = cl_diff

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -251,6 +251,7 @@ class _ComputeSlipstreamOpenvsp(OpenVSPSimpleGeometryDP):
         wing_rotor = self.compute_wing_rotor(
             inputs, outputs, altitude, mach, alpha_max, thrust, shaft_power
         )
+
         wing = self.compute_aero(
             inputs, outputs, altitude, mach, alpha_max, comp_opt="wing", use_cache=True
         )

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -244,9 +244,9 @@ class _ComputeSlipstreamOpenvsp(OpenVSPSimpleGeometryDP):
         # will appear, this is taken as the angle for which the clean wing is at its max angle of
         # attack
 
-        alpha_max = round(float((cl_max_clean - cl0) / cl_alpha), 2)
-        thrust = round(float(inputs["thrust"]), 1)
-        shaft_power = round(float(inputs["shaft_power"]), 1)
+        alpha_max = round((cl_max_clean.item() - cl0.item()) / cl_alpha.item(), 2)
+        thrust = round(inputs["thrust"].item(), 1)
+        shaft_power = round(inputs["shaft_power"].item(), 1)
 
         wing_rotor = self.compute_wing_rotor(
             inputs, outputs, altitude, mach, alpha_max, thrust, shaft_power

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -247,6 +247,7 @@ class _ComputeSlipstreamOpenvsp(OpenVSPSimpleGeometryDP):
         alpha_max = round((cl_max_clean.item() - cl0.item()) / cl_alpha.item(), 2)
         thrust = round(inputs["thrust"].item(), 1)
         shaft_power = round(inputs["shaft_power"].item(), 1)
+        mach = round(mach.item(), 3)
 
         wing_rotor = self.compute_wing_rotor(
             inputs, outputs, altitude, mach, alpha_max, thrust, shaft_power

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -17,6 +17,7 @@ import os.path as pth
 from pathlib import Path
 import warnings
 from importlib.resources import path
+import ast
 import json
 import copy
 import atexit
@@ -51,11 +52,13 @@ STDERR_FILE_NAME = "vspaero_calc.err"
 VSPSCRIPT_EXE_NAME = "vspscript.exe"
 VSPAERO_EXE_NAME = "vspaero.exe"
 
-# Sub-dictionary names used inside a geometry cache entry, next to the mach-keyed
-# post-processed results of compute_aero_coeff. They can never collide with a mach
-# key since mach keys are string representations of floats.
+# Sub-dictionary names used inside a geometry cache entry, next to the mach-keyed results.
 RAW_AERO_CACHE_NAMESPACE = "raw_aero"
 ROTOR_CACHE_NAMESPACE = "wing_rotor"
+# Iterative solves (e.g. a trim/AoA search) tend to call compute_aero / compute_wing_rotor
+# several times with AoA values that only differ by convergence noise (a few hundredths of a
+# degree). Snapping the requested AoA onto an already-cached nearby value.
+AOA_SNAP_TOLERANCE_DEG = 0.05
 WING_ROTOR_CONDITION_LABELS = [
     "altitude",
     "mach",
@@ -142,7 +145,14 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                     if all(label in key for label in GEOMETRY_SET_LABELS) and isinstance(
                         value, dict
                     ):
-                        cls._cache[key] = value
+                        # Preserve both branches from the file (not just "openvsp"): this
+                        # class only ever populates/overwrites the "openvsp" branch during a
+                        # run, so the "vlm" branch must be carried through untouched or it
+                        # would be wiped out (replaced by an empty dict) when this class's
+                        # save_cache() writes the in-memory cache back at exit.
+                        entry = cls._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
+                        entry["openvsp"] = value.get("openvsp", value)
+                        entry["vlm"] = value.get("vlm", entry["vlm"])
                         no_openvsp_cache = False
 
         if no_openvsp_cache:
@@ -354,7 +364,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))
 
         # If no result saved for that geometry under this mach condition, computation is done
-        if self._cache.get(key) is None or self._cache[key].get(str(mach)) is None:
+        if self._cache.get(key) is None or self._cache[key]["openvsp"].get(str(mach)) is None:
             self.register_geometry(key)
 
             # Compute wing alone @ 0°/X° angle of attack
@@ -487,6 +497,13 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             round(float(aoa_angle), 2),
         ]
 
+        self.register_geometry(key)
+        namespace_cache = self._cache[key]["openvsp"].setdefault(RAW_AERO_CACHE_NAMESPACE, {})
+        aoa_index = RAW_AERO_CONDITION_LABELS.index("AoA")
+        condition_values[aoa_index] = self._snap_to_cached_aoa(
+            namespace_cache, RAW_AERO_CONDITION_LABELS, condition_values
+        )
+
         condition_key = str(dict(zip(RAW_AERO_CONDITION_LABELS, condition_values)))
 
         result = self.get_or_compute_cached(
@@ -523,9 +540,6 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         :return: wing/htp and aircraft dictionaries including their respective aerodynamic
         coefficients
         """
-        _LOGGER.info(
-            "Entring OpenVSP aerodynamic evaluation for %s at altitude %.1f m, Mach %.3f, AoA %.2f°",
-        )
 
         output_result = {}
         # STEP 1/XX - DEFINE OR CALCULATE INPUT DATA FOR AERODYNAMIC EVALUATION ####################
@@ -1119,20 +1133,88 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
     def register_geometry(self, key):
         """Register the geometry set as a key in the in-memory cache."""
-        self._cache.setdefault(key, {})
+        self._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
 
     def save_results(self, key, results, mach):
         """Store OpenVSP results in the in-memory cache."""
-        self._cache[key][str(mach)] = dict(zip(RESULT_LABELS, results))
+        self._cache[key]["openvsp"][str(mach)] = dict(zip(RESULT_LABELS, results))
+
+    @staticmethod
+    def _snap_to_cached_aoa(
+        namespace_cache,
+        condition_labels,
+        condition_values,
+        tolerance=AOA_SNAP_TOLERANCE_DEG,
+        aoa_label="AoA",
+    ):
+        """
+        Look for an already-cached condition, in `namespace_cache`, that matches
+        `condition_values` on every field except AoA, and whose AoA is within
+        `tolerance` degrees of the requested one. If found, return that stored
+        AoA value instead of the requested one so that building the condition_key
+        from it collapses onto the existing entry (a cache hit) rather than
+        creating a new, near-duplicate one.
+
+        :param namespace_cache: the ``self._cache[key]["openvsp"][namespace]`` dict,
+            mapping existing condition_key strings to their cached results
+        :param condition_labels: ordered field names used to build condition_key
+            (e.g. RAW_AERO_CONDITION_LABELS)
+        :param condition_values: ordered field values for the condition being
+            looked up, matching `condition_labels`
+        :param tolerance: maximum AoA difference, in degrees, for two conditions
+            to be considered the same
+        :param aoa_label: the label identifying the AoA field within
+            `condition_labels`
+        :return: the AoA value to use when building condition_key - either the
+            requested one unchanged (no close-enough match found) or a
+            previously-cached nearby AoA (match found)
+        """
+        aoa_index = condition_labels.index(aoa_label)
+        requested_aoa = condition_values[aoa_index]
+
+        best_aoa = None
+        best_diff = tolerance
+
+        for stored_key in namespace_cache:
+            try:
+                stored_condition = ast.literal_eval(stored_key)
+            except (ValueError, SyntaxError):
+                # Not a condition_key we can parse back (shouldn't happen for
+                # entries this class wrote itself); skip rather than fail.
+                continue
+
+            stored_values = [stored_condition.get(label) for label in condition_labels]
+
+            # Every field but AoA must match exactly for the two conditions to
+            # represent the same physical case.
+            others_match = all(
+                stored_values[i] == condition_values[i]
+                for i in range(len(condition_labels))
+                if i != aoa_index
+            )
+            if not others_match:
+                continue
+
+            stored_aoa = stored_values[aoa_index]
+            if stored_aoa is None:
+                continue
+
+            diff = abs(stored_aoa - requested_aoa)
+            if diff <= best_diff:
+                best_diff = diff
+                best_aoa = stored_aoa
+
+        return best_aoa if best_aoa is not None else requested_aoa
 
     def get_or_compute_cached(self, key, namespace, condition_key, compute_fn):
         """
         Generic check-cache/compute-on-miss/store helper for raw OpenVSP results.
 
-        Results are stored under ``self._cache[key][namespace][condition_key]`` so
-        that they live next to the mach-keyed post-processed results used by
-        :meth:`compute_aero_coeff` and are persisted/reloaded by the same
-        ``save_cache``/``load_cache`` mechanism without any change.
+        Results are stored under ``self._cache[key]["openvsp"][namespace][condition_key]``
+        so that they live nested under the OpenVSP slot of the cache (alongside the
+        mach-keyed post-processed results used by :meth:`compute_aero_coeff`) and are
+        persisted/reloaded by the same ``save_cache``/``load_cache`` mechanism without
+        any change.
 
         A deep copy of the cached value is returned so that callers mutating the
         result in place (e.g. padding vectors with ``list.extend``) cannot corrupt
@@ -1146,7 +1228,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         :return: the (copied) cached result
         """
         self.register_geometry(key)
-        namespace_cache = self._cache[key].setdefault(namespace, {})
+        namespace_cache = self._cache[key]["openvsp"].setdefault(namespace, {})
 
         if condition_key not in namespace_cache:
             namespace_cache[condition_key] = compute_fn()
@@ -1286,7 +1368,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         :return: aerodynamic characteristic parameters of wing and horizontal stabilizer
         """
-        data = self._cache[key][str(mach)]
+        data = self._cache[key]["openvsp"][str(mach)]
         saved_area_wing = data.get("saved_ref_area")
         saved_area_ratio = data.get("area_ratio")
         cl_0_wing = data.get("cl_0_wing")
@@ -1418,6 +1500,13 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
             y_ratio_key,
         ]
 
+        self.register_geometry(key)
+        namespace_cache = self._cache[key]["openvsp"].setdefault(ROTOR_CACHE_NAMESPACE, {})
+        aoa_index = WING_ROTOR_CONDITION_LABELS.index("AoA")
+        condition_values[aoa_index] = self._snap_to_cached_aoa(
+            namespace_cache, WING_ROTOR_CONDITION_LABELS, condition_values
+        )
+
         condition_key = str(dict(zip(WING_ROTOR_CONDITION_LABELS, condition_values)))
 
         return self.get_or_compute_cached(
@@ -1451,15 +1540,6 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
         #  gives same results...
         # STEP 1/XX - DEFINE OR CALCULATE INPUT DATA FOR AERODYNAMIC EVALUATION ####################
         ############################################################################################
-
-        _LOGGER.info(
-            "Computing OpenVSP wing+rotor for altitude=%s, mach=%s, aoa=%s, thrust=%s, power=%s",
-            altitude,
-            mach,
-            aoa_angle,
-            thrust,
-            power,
-        )
 
         # Get inputs (and calculate missing ones)
         s_ref_wing = float(inputs["data:geometry:wing:area"])

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -507,11 +507,12 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         self.register_geometry(key)
         namespace_cache = self._cache[key]["openvsp"].setdefault(RAW_AERO_CACHE_NAMESPACE, {})
-        condition_values[3] = self._snap_to_cached_aoa(
-            namespace_cache, RAW_AERO_CONDITION_LABELS, condition_values
+        clean_aero_condition = dict(zip(RAW_AERO_CONDITION_LABELS, condition_values))
+        clean_aero_condition["AoA"] = self._snap_to_cached_aoa(
+            namespace_cache, clean_aero_condition
         )
 
-        condition_key = str(dict(zip(RAW_AERO_CONDITION_LABELS, condition_values)))
+        condition_key = str(clean_aero_condition)
 
         result = self.get_or_compute_cached(
             key,
@@ -1145,35 +1146,32 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
     @staticmethod
     def _snap_to_cached_aoa(
         namespace_cache,
-        condition_labels,
-        condition_values,
+        condition_dict,
         tolerance=AOA_SNAP_TOLERANCE_DEG,
         aoa_label="AoA",
     ):
         """
         Look for an already-cached condition, in `namespace_cache`, that matches
-        `condition_values` on every field except AoA, and whose AoA is within
-        `tolerance` degrees of the requested one. If found, return that stored
-        AoA value instead of the requested one so that building the condition_key
-        from it collapses onto the existing entry (a cache hit) rather than
-        creating a new, near-duplicate one.
+        `condition_dict` on every field except AoA, and whose AoA is within
+        `tolerance` degrees of the requested one If found, return that
+        stored AoA value instead of the requested one so that building the
+        condition_key from it collapses onto the existing entry (a cache hit)
+        rather than creating a new, near-duplicate one.
 
         :param namespace_cache: the ``self._cache[key]["openvsp"][namespace]`` dict,
             mapping existing condition_key strings to their cached results
-        :param condition_labels: ordered field names used to build condition_key
-            (e.g. RAW_AERO_CONDITION_LABELS)
-        :param condition_values: ordered field values for the condition being
-            looked up, matching `condition_labels`
+        :param condition_dict: the requested condition, as a dict mapping each
+            condition label to its value (including the AoA field identified by
+            `aoa_label`), used to compare against each stored condition
         :param tolerance: maximum AoA difference, in degrees, for two conditions
             to be considered the same
-        :param aoa_label: the label identifying the AoA field within
-            `condition_labels`
+        :param aoa_label: the key identifying the AoA field within
+            `condition_dict` (and within each stored condition)
         :return: the AoA value to use when building condition_key - either the
-            requested one unchanged (no close-enough match found) or a
-            previously-cached nearby AoA (match found)
+            requested one unchanged (no close-enough match found) or the
+            closest previously-cached AoA within `tolerance` (match found)
         """
-        aoa_index = condition_labels.index(aoa_label)
-        requested_aoa = condition_values[aoa_index]
+        requested_aoa = condition_dict[aoa_label]
 
         best_aoa = None
         best_diff = tolerance
@@ -1186,19 +1184,17 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 # entries this class wrote itself); skip rather than fail.
                 continue
 
-            stored_values = [stored_condition.get(label) for label in condition_labels]
-
             # Every field but AoA must match exactly for the two conditions to
             # represent the same physical case.
             others_match = all(
-                stored_values[i] == condition_values[i]
-                for i in range(len(condition_labels))
-                if i != aoa_index
+                condition_dict[key] == value
+                for key, value in stored_condition.items()
+                if key != aoa_label
             )
             if not others_match:
                 continue
 
-            stored_aoa = stored_values[aoa_index]
+            stored_aoa = stored_condition.get(aoa_label)
             if stored_aoa is None:
                 continue
 
@@ -1502,11 +1498,12 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
 
         self.register_geometry(key)
         namespace_cache = self._cache[key]["openvsp"].setdefault(WING_ROTOR_CACHE_NAMESPACE, {})
-        condition_values[2] = self._snap_to_cached_aoa(
-            namespace_cache, WING_ROTOR_CONDITION_LABELS, condition_values
+        wing_rotor_condition = dict(zip(WING_ROTOR_CONDITION_LABELS, condition_values))
+        wing_rotor_condition["AoA"] = self._snap_to_cached_aoa(
+            namespace_cache, wing_rotor_condition
         )
 
-        condition_key = str(dict(zip(WING_ROTOR_CONDITION_LABELS, condition_values)))
+        condition_key = str(wing_rotor_condition)
 
         return self.get_or_compute_cached(
             key,

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -19,7 +19,6 @@ import warnings
 from importlib.resources import path
 import ast
 import json
-import copy
 import atexit
 import logging
 import numpy as np
@@ -52,9 +51,10 @@ STDERR_FILE_NAME = "vspaero_calc.err"
 VSPSCRIPT_EXE_NAME = "vspscript.exe"
 VSPAERO_EXE_NAME = "vspaero.exe"
 
-# Sub-dictionary names used inside a geometry cache entry, next to the mach-keyed results.
+# Sub-dictionary names used inside a geometry cache entry, next to the mach-keyed results under
+# OpenVSP.
 RAW_AERO_CACHE_NAMESPACE = "raw_aero"
-ROTOR_CACHE_NAMESPACE = "wing_rotor"
+WING_ROTOR_CACHE_NAMESPACE = "wing_rotor"
 # Iterative solves (e.g. a trim/AoA search) tend to call compute_aero / compute_wing_rotor
 # several times with AoA values that only differ by convergence noise (a few hundredths of a
 # degree). Snapping the requested AoA onto an already-cached nearby value.
@@ -151,8 +151,17 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                         # would be wiped out (replaced by an empty dict) when this class's
                         # save_cache() writes the in-memory cache back at exit.
                         entry = cls._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
-                        entry["openvsp"] = value.get("openvsp", value)
-                        entry["vlm"] = value.get("vlm", entry["vlm"])
+
+                        is_legacy_cache = "vlm" not in value and "openvsp" not in value
+                        if is_legacy_cache:
+                            entry["openvsp"] = value
+                        else:
+                            if value.get("openvsp"):
+                                entry["openvsp"] = value["openvsp"]
+
+                            if value.get("vlm"):
+                                entry["vlm"] = value["vlm"]
+
                         no_openvsp_cache = False
 
         if no_openvsp_cache:
@@ -206,12 +215,12 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             return
         # The resolved folder path
         resolved = (
-            OpenVSPSimpleGeometry._resolve_cache_path(folder_path, file_name).parent
+            self._resolve_cache_path(folder_path, file_name).parent
             if file_name
             else Path(folder_path).resolve()
         )
 
-        # Prevent reloading the cache if it's already been loaded from the same path.
+        # Prevent reloading the cache if it's already been loaded.
         if OpenVSPSimpleGeometry._cache_loaded_from is None:
             OpenVSPSimpleGeometry.load_cache(resolved)
 
@@ -348,9 +357,9 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         @param altitude: altitude for aerodynamic calculation in meters
         @param mach: air speed expressed in mach
         @param aoa_angle: air speed angle of attack with respect to aircraft
-        @return: cl_0_wing, cl_alpha_wing, cm_0_wing, y_vector_wing, cl_vector_wing, coef_k_wing,
+        @return: cl_0_wing, cl_alpha_wing, cm_0_wing, y_vector_wing, cl_vector_wing, coeff_k_wing,
         cl_0_htp,  cl_aoa_htp, cl_alpha_htp, cl_alpha_htp_isolated, y_vector_htp, cl_vector_htp,
-        coef_k_htp parameters.
+        coeff_k_htp parameters.
         """
 
         # Fix mach number of digits to consider similar results
@@ -397,7 +406,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 y_vector_wing,
                 cl_vector_wing,
                 chord_vector_wing,
-                coef_k_wing,
+                coeff_k_wing,
             ) = self.post_process_wing(inputs, wing_0, wing_aoa, s_ref_wing, aoa_angle)
 
             # Post-process HTP data ----------------------------------------------------------------
@@ -408,7 +417,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 cl_alpha_htp_isolated,
                 y_vector_htp,
                 cl_vector_htp,
-                coef_k_htp,
+                coeff_k_htp,
             ) = self.post_process_htp(
                 htp_0, htp_aoa, htp_0_isolated, htp_aoa_isolated, aoa_angle, area_ratio
             )
@@ -428,14 +437,14 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 np.array(y_vector_wing).tolist(),
                 np.array(cl_vector_wing).tolist(),
                 np.array(chord_vector_wing).tolist(),
-                float(coef_k_wing),
+                float(coeff_k_wing),
                 float(cl_0_htp),
                 float(cl_aoa_htp),
                 float(cl_alpha_htp),
                 float(cl_alpha_htp_isolated),
                 np.array(y_vector_htp).tolist(),
                 np.array(cl_vector_htp).tolist(),
-                float(coef_k_htp),
+                float(coeff_k_htp),
                 float(s_ref_wing),
                 float(area_ratio),
             ]
@@ -498,8 +507,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         self.register_geometry(key)
         namespace_cache = self._cache[key]["openvsp"].setdefault(RAW_AERO_CACHE_NAMESPACE, {})
-        aoa_index = RAW_AERO_CONDITION_LABELS.index("AoA")
-        condition_values[aoa_index] = self._snap_to_cached_aoa(
+        condition_values[3] = self._snap_to_cached_aoa(
             namespace_cache, RAW_AERO_CONDITION_LABELS, condition_values
         )
 
@@ -951,7 +959,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 "cl": cl_wing,
                 "cdi": cdi_wing,
                 "cm": cm_wing,
-                "coef_e": wing_e,
+                "coeff_e": wing_e,
             }
             output_result = wing
         elif comp_opt == "htp":
@@ -998,7 +1006,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 "cl": cl_htp,
                 "cdi": cdi_htp,
                 "cm": cm_htp,
-                "coef_e": htp_e,
+                "coeff_e": htp_e,
             }
             output_result = htp
         elif comp_opt == "ac":
@@ -1080,7 +1088,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 "cl": aircraft_cl,
                 "cd0": aircraft_cd0,
                 "cdi": aircraft_cdi,
-                "coef_e": aircraft_e,
+                "coeff_e": aircraft_e,
             }
             output_result = wing, htp, aircraft
 
@@ -1211,10 +1219,6 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         persisted/reloaded by the same ``save_cache``/``load_cache`` mechanism without
         any change.
 
-        A deep copy of the cached value is returned so that callers mutating the
-        result in place (e.g. padding vectors with ``list.extend``) cannot corrupt
-        the cache for subsequent retrievals.
-
         :param key: geometry cache key, as built from GEOMETRY_SET_LABELS
         :param namespace: sub-dictionary name (e.g. RAW_AERO_CACHE_NAMESPACE)
         :param condition_key: string key identifying the run conditions
@@ -1227,7 +1231,8 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         if condition_key not in namespace_cache:
             namespace_cache[condition_key] = compute_fn()
-        return copy.deepcopy(namespace_cache[condition_key])
+
+        return namespace_cache[condition_key]
 
     @staticmethod
     def post_process_wing(inputs, wing_0, wing_aoa, s_ref_wing, aoa_angle):
@@ -1255,8 +1260,8 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         cl_vector_wing = (np.array(wing_aoa["cl_vector"]) * k_fus).tolist()
         chord_vector_wing = wing_aoa["chord_vector"]
         k_fus = 1 - 2 * (width_max / span_wing) ** 2  # Fuselage correction
-        coef_e = float(wing_aoa["coef_e"] * k_fus)
-        coef_k_wing = float(1.0 / (np.pi * span_wing**2 / s_ref_wing * coef_e))
+        coeff_e = float(wing_aoa["coeff_e"] * k_fus)
+        coeff_k_wing = float(1.0 / (np.pi * span_wing**2 / s_ref_wing * coeff_e))
 
         return (
             cl_0_wing,
@@ -1266,7 +1271,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
         )
 
     @staticmethod
@@ -1290,7 +1295,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         cl_0_htp = float(htp_0["cl"])
         cl_aoa_htp = float(htp_aoa["cl"])
         cl_alpha_htp = float((cl_aoa_htp - cl_0_htp) / (aoa_angle * np.pi / 180))
-        coef_k_htp = float(htp_aoa["cdi"]) / cl_aoa_htp**2  # area ratio missing ?
+        coeff_k_htp = float(htp_aoa["cdi"]) / cl_aoa_htp**2  # area ratio missing ?
         y_vector_htp = htp_aoa["y_vector"]
         cl_vector_htp = (np.array(htp_aoa["cl_vector"]) * area_ratio).tolist()
 
@@ -1308,7 +1313,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coef_k_htp,
+            coeff_k_htp,
         )
 
     @staticmethod
@@ -1364,25 +1369,25 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         :return: aerodynamic characteristic parameters of wing and horizontal stabilizer
         """
         data = self._cache[key]["openvsp"][str(mach)]
-        saved_area_wing = data.get("saved_ref_area")
-        saved_area_ratio = data.get("area_ratio")
-        cl_0_wing = data.get("cl_0_wing")
-        cl_x_wing = data.get("cl_X_wing")
-        cl_alpha_wing = data.get("cl_alpha_wing")
-        cm_0_wing = data.get("cm_0_wing")
-        y_vector_wing = np.array(data.get("y_vector_wing")) * np.sqrt(s_ref_wing / saved_area_wing)
-        cl_vector_wing = np.array(data.get("cl_vector_wing"))
-        chord_vector_wing = np.array(data.get("chord_vector_wing")) * np.sqrt(
+        saved_area_wing = data["saved_ref_area"]
+        saved_area_ratio = data["area_ratio"]
+        cl_0_wing = data["cl_0_wing"]
+        cl_x_wing = data["cl_X_wing"]
+        cl_alpha_wing = data["cl_alpha_wing"]
+        cm_0_wing = data["cm_0_wing"]
+        y_vector_wing = np.array(data["y_vector_wing"]) * np.sqrt(s_ref_wing / saved_area_wing)
+        cl_vector_wing = np.array(data["cl_vector_wing"])
+        chord_vector_wing = np.array(data["chord_vector_wing"]) * np.sqrt(
             s_ref_wing / saved_area_wing
         )
-        coef_k_wing = data.get("coef_k_wing")
-        cl_0_htp = data.get("cl_0_htp") * (area_ratio / saved_area_ratio)
-        cl_aoa_htp = data.get("cl_X_htp") * (area_ratio / saved_area_ratio)
-        cl_alpha_htp = data.get("cl_alpha_htp") * (area_ratio / saved_area_ratio)
-        cl_alpha_htp_isolated = data.get("cl_alpha_htp_isolated") * (area_ratio / saved_area_ratio)
-        y_vector_htp = np.array(data.get("y_vector_htp"))
-        cl_vector_htp = np.array(data.get("cl_vector_htp")) * (area_ratio / saved_area_ratio)
-        coef_k_htp = data.get("coef_k_htp") * (area_ratio / saved_area_ratio)
+        coeff_k_wing = data["coeff_k_wing"]
+        cl_0_htp = data["cl_0_htp"] * (area_ratio / saved_area_ratio)
+        cl_aoa_htp = data["cl_X_htp"] * (area_ratio / saved_area_ratio)
+        cl_alpha_htp = data["cl_alpha_htp"] * (area_ratio / saved_area_ratio)
+        cl_alpha_htp_isolated = data["cl_alpha_htp_isolated"] * (area_ratio / saved_area_ratio)
+        y_vector_htp = np.array(data["y_vector_htp"])
+        cl_vector_htp = np.array(data["cl_vector_htp"]) * (area_ratio / saved_area_ratio)
+        coeff_k_htp = data["coeff_k_htp"] * (area_ratio / saved_area_ratio)
 
         return (
             cl_0_wing,
@@ -1392,14 +1397,14 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
             cl_0_htp,
             cl_aoa_htp,
             cl_alpha_htp,
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coef_k_htp,
+            coeff_k_htp,
             s_ref_wing,
             area_ratio,
         )
@@ -1496,9 +1501,8 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
         ]
 
         self.register_geometry(key)
-        namespace_cache = self._cache[key]["openvsp"].setdefault(ROTOR_CACHE_NAMESPACE, {})
-        aoa_index = WING_ROTOR_CONDITION_LABELS.index("AoA")
-        condition_values[aoa_index] = self._snap_to_cached_aoa(
+        namespace_cache = self._cache[key]["openvsp"].setdefault(WING_ROTOR_CACHE_NAMESPACE, {})
+        condition_values[2] = self._snap_to_cached_aoa(
             namespace_cache, WING_ROTOR_CONDITION_LABELS, condition_values
         )
 
@@ -1506,7 +1510,7 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
 
         return self.get_or_compute_cached(
             key,
-            ROTOR_CACHE_NAMESPACE,
+            WING_ROTOR_CACHE_NAMESPACE,
             condition_key,
             lambda: self._compute_wing_rotor(
                 inputs, outputs, altitude, mach, aoa_angle, thrust, power
@@ -1528,7 +1532,7 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
         @param power: total aircraft power for computation of power coefficient (will be divided
         by engine count)
         @return: wing dictionary including aero parameters as keys: y_vector, cl_vector, cd_vector,
-        cm_vector, cl, cdi, cm, coef_e
+        cm_vector, cl, cdi, cm, coeff_e
         """
 
         # TODO : Check for rules that would allow the scaling of these results i.e, same D/span
@@ -1888,7 +1892,7 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
             "cl": cl_wing,
             "cdi": cdi_wing,
             "cm": cm_wing,
-            "coef_e": wing_e,
+            "coeff_e": wing_e,
             "ct": thrust_coefficient,
         }
         return wing_rotor

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -1,6 +1,6 @@
 """Estimation of cl/cm/oswald aero coefficients using OPENVSP."""
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,13 +14,17 @@
 
 import os
 import os.path as pth
+from pathlib import Path
 import warnings
 from importlib.resources import path
-
+import json
+import copy
+import atexit
+import logging
 import numpy as np
-import pandas as pd
 
 from distutils.dir_util import copy_tree
+from typing import Optional, Union
 
 # noinspection PyProtectedMember
 from fastoad._utils.resource_management.copy import copy_resource
@@ -30,12 +34,12 @@ from openmdao.utils.file_wrap import InputFileGenerator
 from stdatm import Atmosphere
 
 # noinspection PyProtectedMember
-from fastga.command.api import _create_tmp_directory, string_to_array
+from fastga.command.api import _create_tmp_directory
 from fastga.utils.resource_management.copy import copy_resource_from_path
 from . import openvsp3201
 from . import resources as local_resources
 from ... import airfoil_folder
-from ...constants import SPAN_MESH_POINT, MACH_NB_PTS
+from ...constants import SPAN_MESH_POINT, MACH_NB_PTS, GEOMETRY_SET_LABELS, RESULT_LABELS
 
 DEFAULT_WING_AIRFOIL = "naca23012.af"
 DEFAULT_HTP_AIRFOIL = "naca0012.af"
@@ -47,9 +51,168 @@ STDERR_FILE_NAME = "vspaero_calc.err"
 VSPSCRIPT_EXE_NAME = "vspscript.exe"
 VSPAERO_EXE_NAME = "vspaero.exe"
 
+# Sub-dictionary names used inside a geometry cache entry, next to the mach-keyed
+# post-processed results of compute_aero_coeff. They can never collide with a mach
+# key since mach keys are string representations of floats.
+RAW_AERO_CACHE_NAMESPACE = "raw_aero"
+ROTOR_CACHE_NAMESPACE = "wing_rotor"
+WING_ROTOR_CONDITION_LABELS = [
+    "altitude",
+    "mach",
+    "AoA",
+    "thrust_coefficient",
+    "power_coefficient",
+    "engine_count",
+    "engine_config",
+    "engine_rpm",
+    "propeller_diameter",
+    "nac_length",
+    "y_ratio_key",
+]
+RAW_AERO_CONDITION_LABELS = ["comp_opt", "altitude", "mach", "AoA"]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _NumpyJSONEncoder(json.JSONEncoder):
+    """JSON encoder that also knows how to serialize numpy arrays/scalars, which
+    the OpenVSP result cache stores (e.g. y_vector_wing, cl_vector_wing)."""
+
+    def default(self, o):
+        if isinstance(o, np.ndarray):
+            return o.tolist()
+        if isinstance(o, np.generic):
+            return o.item()
+        return super().default(o)
+
 
 class OpenVSPSimpleGeometry(ExternalCodeComp):
     """Execution of OpenVSP for clean surfaces."""
+
+    _cache: dict = {}
+
+    # File the cache should be saved to (only set when a `result_file_name` is
+    # configured).
+    _cache_file: Optional[str] = None
+
+    # Folder/file the cache was last loaded from, used only to avoid redundant
+    # reloads on repeated component instantiation. Distinct from `_cache_file`:
+    # this is set even when no `result_file_name` is configured (folder-only mode).
+    _cache_loaded_from: Optional[str] = None
+
+    # Guards against registering the atexit save more than once.
+    _atexit_registered: bool = False
+
+    @staticmethod
+    def _resolve_cache_path(folder_path: Union[str, Path], file_name: str) -> Path:
+        """
+        Turns the `result_folder_path`/`result_file_name` options into the full cache
+        file path.
+        """
+        return (Path(folder_path) / file_name).resolve()
+
+    @classmethod
+    def load_cache(cls, folder_path: Union[str, Path]) -> None:
+        """
+        Loads a previously saved OpenVSP result cache from disk and merges it into the in-memory cache.
+
+        :param folder_path: the result folder (e.g. `result_folder_path`) inside
+            which the cache file lives.
+        """
+
+        search_folder = Path(folder_path).resolve()
+        cls._cache_loaded_from = str(search_folder)
+
+        no_openvsp_cache = True
+
+        for file in search_folder.glob("*.json"):
+            try:
+                with open(file, "r", encoding="utf-8") as cache_fp:
+                    saved_cache = json.load(cache_fp)
+            except (json.JSONDecodeError, OSError) as exc:
+                # The result folder may contain JSON files unrelated to the OpenVSP cache.
+                # Skip them rather than aborting the whole load.
+                _LOGGER.warning("Skipping unreadable cache file %s: %s", file, exc)
+                continue
+
+            if isinstance(saved_cache, dict):
+                for key, value in saved_cache.items():
+                    # Register in cache only if the key contains all the geometry labels
+                    if all(label in key for label in GEOMETRY_SET_LABELS) and isinstance(
+                        value, dict
+                    ):
+                        cls._cache[key] = value
+                        no_openvsp_cache = False
+
+        if no_openvsp_cache:
+            _LOGGER.info("No existing OpenVSP cache found in %s, starting empty.", search_folder)
+        else:
+            _LOGGER.info(
+                "Loaded OpenVSP cache from %s (%d geometry entries).",
+                search_folder,
+                len(cls._cache),
+            )
+
+    @classmethod
+    def save_cache(
+        cls,
+        folder_path: Optional[Union[str, Path]] = None,
+        file_name: Optional[str] = None,
+    ) -> None:
+        """
+        Persists the current in-memory OpenVSP result cache to disk so it can be reused
+        by a later run via `load_cache`. Intended to be called once, at the end of
+        a run.
+
+        :param folder_path: raw result folder to save into, together with `file_name`.
+             Ignored unless `file_name` is given.
+        :param file_name: cache file name to use together with `folder_path`.
+        """
+        if folder_path is not None and file_name:
+            path = cls._resolve_cache_path(folder_path, file_name)
+        elif cls._cache_file is not None:
+            path = Path(cls._cache_file)
+        else:
+            _LOGGER.warning("save_cache() called with no folder_path and none set; skipping.")
+            return
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf8") as cache_fp:
+            json.dump(cls._cache, cache_fp, cls=_NumpyJSONEncoder, indent=2)
+
+        cls._cache_file = str(path)
+        _LOGGER.info("Saved OpenVSP cache to %s (%d geometry entries).", path, len(cls._cache))
+
+    def _setup_cache_persistence(self) -> None:
+        """
+        Loads any existing cache from `result_folder_path`/`result_file_name` and
+        registers an `atexit` callback process that writes the cache into the
+        json file when the process ends.
+        """
+        folder_path = self.options["result_folder_path"]
+        file_name = self.options["result_file_name"]
+        if not folder_path and not file_name:
+            return
+        # The resolved folder path
+        resolved = (
+            OpenVSPSimpleGeometry._resolve_cache_path(folder_path, file_name).parent
+            if file_name
+            else Path(folder_path).resolve()
+        )
+
+        # Prevent reloading the cache if it's already been loaded from the same path.
+        if OpenVSPSimpleGeometry._cache_loaded_from is None:
+            OpenVSPSimpleGeometry.load_cache(folder_path)
+
+        # Register the atexit callback process only once, since multiple instances of this
+        # component may be created. Only register it when `result_file_name` is set.
+        if not OpenVSPSimpleGeometry._atexit_registered:
+            if resolved is not None and file_name:
+                atexit.register(
+                    OpenVSPSimpleGeometry.save_cache, folder_path=folder_path, file_name=file_name
+                )
+            OpenVSPSimpleGeometry._atexit_registered = True
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -57,6 +220,13 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
     def initialize(self):
         self.options.declare("result_folder_path", default="", types=str)
+        self.options.declare(
+            "result_file_name",
+            default="",
+            types=str,
+            desc="Name of the file to store the results cache as a JSON file. If not set, "
+            "the cache will not be saved to disk.",
+        )
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
         self.options.declare(
@@ -67,6 +237,9 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         )
 
     def setup(self):
+        # Setup cache persistence, placed under setup() due to options usage.
+        self._setup_cache_persistence()
+
         self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="deg")
         self.add_input("data:geometry:wing:taper_ratio", val=np.nan)
         self.add_input("data:geometry:wing:aspect_ratio", val=np.nan)
@@ -165,37 +338,24 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         @param altitude: altitude for aerodynamic calculation in meters
         @param mach: air speed expressed in mach
         @param aoa_angle: air speed angle of attack with respect to aircraft
-        @return: cl_0_wing, cl_alpha_wing, cm_0_wing, y_vector_wing, cl_vector_wing, coeff_k_wing,
+        @return: cl_0_wing, cl_alpha_wing, cm_0_wing, y_vector_wing, cl_vector_wing, coef_k_wing,
         cl_0_htp,  cl_aoa_htp, cl_alpha_htp, cl_alpha_htp_isolated, y_vector_htp, cl_vector_htp,
-        coeff_k_htp parameters.
+        coef_k_htp parameters.
         """
         # initialize
-        results = [None] * 16
+        results = [None] * 17
         # Fix mach number of digits to consider similar results
         mach = round(float(mach) * 1e3) / 1e3
 
         # Get inputs necessary to define global geometry
-        s_ref_wing, area_ratio, geometry_set = self.define_geometry(inputs, mach)
+        s_ref_wing, area_ratio, geometry_set = self.define_geometry(inputs)
 
-        # Search if results already exist:
-        result_folder_path = self.options["result_folder_path"]
-        result_file_path = None
-        saved_area_ratio = 1.0
-        if result_folder_path != "":
-            result_file_path, saved_area_ratio = self.search_results(
-                result_folder_path, geometry_set
-            )
+        # Create a key to store/retrieve results in cache
+        key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))
 
         # If no result saved for that geometry under this mach condition, computation is done
-        if result_file_path is None:
-            # Create result folder first (if it must fail, let it fail as soon as possible)
-            if result_folder_path != "":
-                if not os.path.exists(result_folder_path):
-                    os.makedirs(pth.join(result_folder_path), exist_ok=True)
-
-            # Save the geometry (result_file_path is None entering the function)
-            if self.options["result_folder_path"] != "":
-                result_file_path = self.save_geometry(result_folder_path, geometry_set)
+        if self._cache.get(key) is None or self._cache[key].get(str(mach)) is None:
+            self.register_geometry(key)
 
             # Compute wing alone @ 0°/X° angle of attack
             wing_0 = self.compute_aero(inputs, outputs, altitude, mach, 0.0, comp_opt="wing")
@@ -228,7 +388,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 y_vector_wing,
                 cl_vector_wing,
                 chord_vector_wing,
-                coeff_k_wing,
+                coef_k_wing,
             ) = self.post_process_wing(inputs, wing_0, wing_aoa, s_ref_wing, aoa_angle)
 
             # Post-process HTP data ----------------------------------------------------------------
@@ -239,7 +399,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 cl_alpha_htp_isolated,
                 y_vector_htp,
                 cl_vector_htp,
-                coeff_k_htp,
+                coef_k_htp,
             ) = self.post_process_htp(
                 htp_0, htp_aoa, htp_0_isolated, htp_aoa_isolated, aoa_angle, area_ratio
             )
@@ -251,39 +411,107 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             y_vector_htp, cl_vector_htp = self.resize_vector(vector_htp)
 
             # Save results to defined path ---------------------------------------------------------
-            if self.options["result_folder_path"] != "":
-                results = [
-                    float(cl_0_wing),
-                    float(cl_x_wing),
-                    float(cl_alpha_wing),
-                    float(cm_0_wing),
-                    np.array(y_vector_wing).tolist(),
-                    np.array(cl_vector_wing).tolist(),
-                    np.array(chord_vector_wing).tolist(),
-                    float(coeff_k_wing),
-                    float(cl_0_htp),
-                    float(cl_aoa_htp),
-                    float(cl_alpha_htp),
-                    float(cl_alpha_htp_isolated),
-                    np.array(y_vector_htp).tolist(),
-                    np.array(cl_vector_htp).tolist(),
-                    float(coeff_k_htp),
-                    float(s_ref_wing),
-                ]
-                self.save_results(result_file_path, results)
+            results = [
+                float(cl_0_wing),
+                float(cl_x_wing),
+                float(cl_alpha_wing),
+                float(cm_0_wing),
+                np.array(y_vector_wing).tolist(),
+                np.array(cl_vector_wing).tolist(),
+                np.array(chord_vector_wing).tolist(),
+                float(coef_k_wing),
+                float(cl_0_htp),
+                float(cl_aoa_htp),
+                float(cl_alpha_htp),
+                float(cl_alpha_htp_isolated),
+                np.array(y_vector_htp).tolist(),
+                np.array(cl_vector_htp).tolist(),
+                float(coef_k_htp),
+                float(s_ref_wing),
+                float(area_ratio),
+            ]
+
+            self.save_results(key, results, mach)
 
         # Else retrieved results are used, eventually adapted with new area ratio
         else:
             # Read values from result file ---------------------------------------------------------
-            data = self.read_results(result_file_path)
-            results = self.assign_read_data(data, area_ratio, saved_area_ratio, s_ref_wing)
-        return results
+            results = self.assign_read_data(key, mach, s_ref_wing, area_ratio)
 
-    def compute_aero(self, inputs, outputs, altitude, mach, aoa_angle, comp_opt="wing"):
+        # last two values are s_ref_wing and area_ratio, not needed in return
+
+        return results[:-1]
+
+    def compute_aero(
+        self, inputs, outputs, altitude, mach, aoa_angle, comp_opt="wing", use_cache=False
+    ):
+        """
+        Thin cache-checking wrapper around :meth:`_compute_aero_impl`, which does the
+        actual OpenVSP run. Mirrors the compute_wing_rotor / _compute_wing_rotor split:
+        this method itself never runs OpenVSP - it either calls the impl directly
+        (use_cache=False) or looks the result up in (and stores it into) the in-memory
+        cache before calling the impl on a miss (use_cache=True). Keeping the cache
+        check and the actual computation in two separate methods means the cache-miss
+        branch can call the impl unconditionally, with no risk of accidentally
+        re-entering the cache-check branch and recursing forever.
+
+        :param inputs: inputs parameters defined within FAST-OAD-GA
+        :param outputs: outputs parameters defined within FAST-OAD-GA
+        :param altitude: altitude for aerodynamic calculation in meters
+        :param mach: air speed expressed in mach
+        :param aoa_angle: air speed angle of attack with respect to aircraft
+        :param comp_opt: component to evaluate can be "wing", "htp" or "ac"
+        :param use_cache: if True, the raw OpenVSP result is looked up in (and stored
+            into) the in-memory cache, keyed by geometry, comp_opt, altitude, mach and
+            aoa_angle, so the OpenVSP run is skipped when an identical combination has
+            already been computed. Defaults to False so the calls made by
+            compute_aero_coeff (which caches its own post-processed results) are
+            unaffected.
+
+        :return: wing/htp and aircraft dictionaries including their respective aerodynamic
+        coefficients
+        """
+        if not use_cache:
+            return self._compute_aero(inputs, outputs, altitude, mach, aoa_angle, comp_opt)
+
+        # Fix mach number of digits to consider similar results (same rounding as
+        # compute_aero_coeff)
+        mach = round(float(mach) * 1e3) / 1e3
+
+        _, _, geometry_set = self.define_geometry(inputs)
+        key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))
+        condition_values = [
+            comp_opt,
+            round(float(altitude), 1),
+            mach,
+            round(float(aoa_angle), 2),
+        ]
+
+        condition_key = str(dict(zip(RAW_AERO_CONDITION_LABELS, condition_values)))
+
+        result = self.get_or_compute_cached(
+            key,
+            RAW_AERO_CACHE_NAMESPACE,
+            condition_key,
+            lambda: self._compute_aero(inputs, outputs, altitude, mach, aoa_angle, comp_opt),
+        )
+        # The "ac" option returns a (wing, htp, aircraft) tuple, which a JSON
+        # save/load round-trip of the cache turns into a list. Normalize back so
+        # the return type does not depend on where the result came from.
+        if comp_opt == "ac" and isinstance(result, list):
+            result = tuple(result)
+        return result
+
+    def _compute_aero(self, inputs, outputs, altitude, mach, aoa_angle, comp_opt="wing"):
         """
         Function that computes in OpenVSP environment the wing, horizontal stablizer(htp),
         and complete aircraft (considering wing and horizontal tail plan) and returns the
         different aerodynamic parameters. The downwash is done by OpenVSP considering far field.
+
+        This is the actual (expensive) OpenVSP run, with no `use_cache` parameter by
+        design. Call `compute_aero` instead, which decides whether to consult the cache
+        before reaching this method - that keeps this method itself free of any cache
+        logic it could recurse into.
 
         :param inputs: inputs parameters defined within FAST-OAD-GA
         :param outputs: outputs parameters defined within FAST-OAD-GA
@@ -295,6 +523,10 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         :return: wing/htp and aircraft dictionaries including their respective aerodynamic
         coefficients
         """
+        _LOGGER.info(
+            "Entring OpenVSP aerodynamic evaluation for %s at altitude %.1f m, Mach %.3f, AoA %.2f°",
+        )
+
         output_result = {}
         # STEP 1/XX - DEFINE OR CALCULATE INPUT DATA FOR AERODYNAMIC EVALUATION ####################
         ############################################################################################
@@ -710,7 +942,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 "cl": cl_wing,
                 "cdi": cdi_wing,
                 "cm": cm_wing,
-                "coeff_e": wing_e,
+                "coef_e": wing_e,
             }
             output_result = wing
         elif comp_opt == "htp":
@@ -757,7 +989,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 "cl": cl_htp,
                 "cdi": cdi_htp,
                 "cm": cm_htp,
-                "coeff_e": htp_e,
+                "coef_e": htp_e,
             }
             output_result = htp
         elif comp_opt == "ac":
@@ -839,130 +1071,18 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                 "cl": aircraft_cl,
                 "cd0": aircraft_cd0,
                 "cdi": aircraft_cdi,
-                "coeff_e": aircraft_e,
+                "coef_e": aircraft_e,
             }
             output_result = wing, htp, aircraft
 
         return output_result
 
     @staticmethod
-    def search_results(result_folder_path, geometry_set):
-        """Search the results folder to see if the geometry has already been calculated."""
-        result_file_path = None
-        saved_area_ratio = 1.0
-        if os.path.exists(result_folder_path):
-            geometry_set_labels = [
-                "sweep25_wing",
-                "taper_ratio_wing",
-                "aspect_ratio_wing",
-                "dihedral_angle_wing",
-                "twist_angle_wing",
-                "sweep25_htp",
-                "taper_ratio_htp",
-                "aspect_ratio_htp",
-                "mach",
-                "area_ratio",
-            ]
-            # If some results already stored search for corresponding geometry
-            if pth.exists(pth.join(result_folder_path, "geometry_0.csv")):
-                idx = 0
-                while pth.exists(pth.join(result_folder_path, "geometry_" + str(idx) + ".csv")):
-                    if pth.exists(pth.join(result_folder_path, "openvsp_" + str(idx) + ".csv")):
-                        data = pd.read_csv(
-                            pth.join(result_folder_path, "geometry_" + str(idx) + ".csv")
-                        )
-                        values = data.to_numpy()[:, 1].tolist()
-                        labels = data.to_numpy()[:, 0].tolist()
-                        data = pd.DataFrame(values, index=labels)
-                        # noinspection PyBroadException
-                        try:
-                            if (
-                                np.size(data.loc[geometry_set_labels[0:-1], 0].to_numpy())
-                                == len(geometry_set_labels) - 1
-                            ):
-                                saved_set = np.around(
-                                    data.loc[geometry_set_labels[0:-1], 0].to_numpy(),
-                                    decimals=6,
-                                )
-                                if (
-                                    np.sum(saved_set == geometry_set[0:-1])
-                                    == len(geometry_set_labels) - 1
-                                ):
-                                    result_file_path = pth.join(
-                                        result_folder_path,
-                                        "openvsp_" + str(idx) + ".csv",
-                                    )
-                                    saved_area_ratio = data.loc["area_ratio", 0]
-                                    return result_file_path, saved_area_ratio
-                        except Exception:
-                            break
-                    idx += 1
-
-        return result_file_path, saved_area_ratio
-
-    @staticmethod
-    def save_geometry(result_folder_path, geometry_set):
-        """Save geometry if not already computed by finding first available index."""
-        geometry_set_labels = [
-            "sweep25_wing",
-            "taper_ratio_wing",
-            "aspect_ratio_wing",
-            "dihedral_angle_wing",
-            "twist_angle_wing",
-            "sweep25_htp",
-            "taper_ratio_htp",
-            "aspect_ratio_htp",
-            "mach",
-            "area_ratio",
-        ]
-        data = pd.DataFrame(geometry_set, index=geometry_set_labels)
-        idx = 0
-        while pth.exists(pth.join(result_folder_path, "geometry_" + str(idx) + ".csv")):
-            idx += 1
-        data.to_csv(pth.join(result_folder_path, "geometry_" + str(idx) + ".csv"))
-        result_file_path = pth.join(result_folder_path, "openvsp_" + str(idx) + ".csv")
-
-        return result_file_path
-
-    @staticmethod
-    def save_results(result_file_path, results):
-        """Reads saved results."""
-        labels = [
-            "cl_0_wing",
-            "cl_X_wing",
-            "cl_alpha_wing",
-            "cm_0_wing",
-            "y_vector_wing",
-            "cl_vector_wing",
-            "chord_vector_wing",
-            "coeff_k_wing",
-            "cl_0_htp",
-            "cl_X_htp",
-            "cl_alpha_htp",
-            "cl_alpha_htp_isolated",
-            "y_vector_htp",
-            "cl_vector_htp",
-            "coeff_k_htp",
-            "saved_ref_area",
-        ]
-        data = pd.DataFrame(results, index=labels)
-        data.to_csv(result_file_path)
-
-    @staticmethod
-    def read_results(result_file_path):
-        data = pd.read_csv(result_file_path)
-        values = data.to_numpy()[:, 1].tolist()
-        labels = data.to_numpy()[:, 0].tolist()
-
-        return pd.DataFrame(values, index=labels)
-
-    @staticmethod
-    def define_geometry(inputs, mach):
+    def define_geometry(inputs):
         """
         Extract geometrical parameters
 
         :param inputs: inputs in the OpenMDAO format
-        :param mach: Mach number
 
         :return s_ref_wing: wing reference surface area
         :return area_ratio: rea ratio between wing and horizontal stabilizer
@@ -990,14 +1110,47 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                     sweep25_htp,
                     taper_ratio_htp,
                     aspect_ratio_htp,
-                    mach,
-                    area_ratio,
                 ]
             ),
             decimals=6,
         )
 
         return s_ref_wing, area_ratio, geometry_set
+
+    def register_geometry(self, key):
+        """Register the geometry set as a key in the in-memory cache."""
+        self._cache.setdefault(key, {})
+
+    def save_results(self, key, results, mach):
+        """Store OpenVSP results in the in-memory cache."""
+        self._cache[key][str(mach)] = dict(zip(RESULT_LABELS, results))
+
+    def get_or_compute_cached(self, key, namespace, condition_key, compute_fn):
+        """
+        Generic check-cache/compute-on-miss/store helper for raw OpenVSP results.
+
+        Results are stored under ``self._cache[key][namespace][condition_key]`` so
+        that they live next to the mach-keyed post-processed results used by
+        :meth:`compute_aero_coeff` and are persisted/reloaded by the same
+        ``save_cache``/``load_cache`` mechanism without any change.
+
+        A deep copy of the cached value is returned so that callers mutating the
+        result in place (e.g. padding vectors with ``list.extend``) cannot corrupt
+        the cache for subsequent retrievals.
+
+        :param key: geometry cache key, as built from GEOMETRY_SET_LABELS
+        :param namespace: sub-dictionary name (e.g. RAW_AERO_CACHE_NAMESPACE)
+        :param condition_key: string key identifying the run conditions
+        :param compute_fn: zero-argument callable performing the actual (costly)
+            computation, only invoked on a cache miss
+        :return: the (copied) cached result
+        """
+        self.register_geometry(key)
+        namespace_cache = self._cache[key].setdefault(namespace, {})
+
+        if condition_key not in namespace_cache:
+            namespace_cache[condition_key] = compute_fn()
+        return copy.deepcopy(namespace_cache[condition_key])
 
     @staticmethod
     def post_process_wing(inputs, wing_0, wing_aoa, s_ref_wing, aoa_angle):
@@ -1025,8 +1178,8 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         cl_vector_wing = (np.array(wing_aoa["cl_vector"]) * k_fus).tolist()
         chord_vector_wing = wing_aoa["chord_vector"]
         k_fus = 1 - 2 * (width_max / span_wing) ** 2  # Fuselage correction
-        coeff_e = float(wing_aoa["coeff_e"] * k_fus)
-        coeff_k_wing = float(1.0 / (np.pi * span_wing**2 / s_ref_wing * coeff_e))
+        coef_e = float(wing_aoa["coef_e"] * k_fus)
+        coef_k_wing = float(1.0 / (np.pi * span_wing**2 / s_ref_wing * coef_e))
 
         return (
             cl_0_wing,
@@ -1036,7 +1189,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coeff_k_wing,
+            coef_k_wing,
         )
 
     @staticmethod
@@ -1060,7 +1213,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         cl_0_htp = float(htp_0["cl"])
         cl_aoa_htp = float(htp_aoa["cl"])
         cl_alpha_htp = float((cl_aoa_htp - cl_0_htp) / (aoa_angle * np.pi / 180))
-        coeff_k_htp = float(htp_aoa["cdi"]) / cl_aoa_htp**2  # area ratio missing ?
+        coef_k_htp = float(htp_aoa["cdi"]) / cl_aoa_htp**2  # area ratio missing ?
         y_vector_htp = htp_aoa["y_vector"]
         cl_vector_htp = (np.array(htp_aoa["cl_vector"]) * area_ratio).tolist()
 
@@ -1078,7 +1231,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coeff_k_htp,
+            coef_k_htp,
         )
 
     @staticmethod
@@ -1121,8 +1274,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         return resized_vectors
 
-    @staticmethod
-    def assign_read_data(data, area_ratio, saved_area_ratio, s_ref_wing):
+    def assign_read_data(self, key, mach, s_ref_wing, area_ratio):
         """
         When results already exists, read and assign existing data and apply the new area ratio
 
@@ -1134,30 +1286,26 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         :return: aerodynamic characteristic parameters of wing and horizontal stabilizer
         """
-        saved_area_wing = float(data.loc["saved_ref_area", 0])
-        cl_0_wing = float(data.loc["cl_0_wing", 0])
-        cl_x_wing = float(data.loc["cl_X_wing", 0])
-        cl_alpha_wing = float(data.loc["cl_alpha_wing", 0])
-        cm_0_wing = float(data.loc["cm_0_wing", 0])
-        y_vector_wing = string_to_array(data.loc["y_vector_wing", 0][1:-2]) * np.sqrt(
+        data = self._cache[key][str(mach)]
+        saved_area_wing = data.get("saved_ref_area")
+        saved_area_ratio = data.get("area_ratio")
+        cl_0_wing = data.get("cl_0_wing")
+        cl_x_wing = data.get("cl_X_wing")
+        cl_alpha_wing = data.get("cl_alpha_wing")
+        cm_0_wing = data.get("cm_0_wing")
+        y_vector_wing = np.array(data.get("y_vector_wing")) * np.sqrt(s_ref_wing / saved_area_wing)
+        cl_vector_wing = np.array(data.get("cl_vector_wing"))
+        chord_vector_wing = np.array(data.get("chord_vector_wing")) * np.sqrt(
             s_ref_wing / saved_area_wing
         )
-        cl_vector_wing = string_to_array(data.loc["cl_vector_wing", 0][1:-2])
-        chord_vector_wing = string_to_array(data.loc["chord_vector_wing", 0][1:-2]) * np.sqrt(
-            s_ref_wing / saved_area_wing
-        )
-        coeff_k_wing = float(data.loc["coeff_k_wing", 0])
-        cl_0_htp = float(data.loc["cl_0_htp", 0]) * (area_ratio / saved_area_ratio)
-        cl_aoa_htp = float(data.loc["cl_X_htp", 0]) * (area_ratio / saved_area_ratio)
-        cl_alpha_htp = float(data.loc["cl_alpha_htp", 0]) * (area_ratio / saved_area_ratio)
-        cl_alpha_htp_isolated = float(data.loc["cl_alpha_htp_isolated", 0]) * (
-            area_ratio / saved_area_ratio
-        )
-        y_vector_htp = string_to_array(data.loc["y_vector_htp", 0][1:-2])
-        cl_vector_htp = string_to_array(data.loc["cl_vector_htp", 0][1:-2]) * (
-            area_ratio / saved_area_ratio
-        )
-        coeff_k_htp = float(data.loc["coeff_k_htp", 0]) * (area_ratio / saved_area_ratio)
+        coef_k_wing = data.get("coef_k_wing")
+        cl_0_htp = data.get("cl_0_htp") * (area_ratio / saved_area_ratio)
+        cl_aoa_htp = data.get("cl_X_htp") * (area_ratio / saved_area_ratio)
+        cl_alpha_htp = data.get("cl_alpha_htp") * (area_ratio / saved_area_ratio)
+        cl_alpha_htp_isolated = data.get("cl_alpha_htp_isolated") * (area_ratio / saved_area_ratio)
+        y_vector_htp = np.array(data.get("y_vector_htp"))
+        cl_vector_htp = np.array(data.get("cl_vector_htp")) * (area_ratio / saved_area_ratio)
+        coef_k_htp = data.get("coef_k_htp") * (area_ratio / saved_area_ratio)
 
         return (
             cl_0_wing,
@@ -1167,15 +1315,16 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coeff_k_wing,
+            coef_k_wing,
             cl_0_htp,
             cl_aoa_htp,
             cl_alpha_htp,
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coeff_k_htp,
+            coef_k_htp,
             s_ref_wing,
+            area_ratio,
         )
 
 
@@ -1205,6 +1354,83 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
 
     def compute_wing_rotor(self, inputs, outputs, altitude, mach, aoa_angle, thrust, power):
         """
+        Cached wrapper around :meth:`_compute_wing_rotor`.
+
+        Skips the OpenVSP run when an identical combination of geometry, flight
+        condition and propulsion state has already been computed (in this process
+        or in a reloaded cache file). Thrust and power are not cached on their raw
+        values but through the derived, rounded thrust/power coefficients, so that
+        negligible variations between iterations (e.g. finite-difference steps)
+        still produce cache hits, mirroring the mach rounding of
+        :meth:`compute_aero_coeff`.
+
+        Parameters and return value are identical to :meth:`_compute_wing_rotor`.
+        """
+        # Fix mach number of digits to consider similar results (same rounding as
+        # compute_aero_coeff)
+        mach = round(float(mach) * 1e3) / 1e3
+
+        _, _, geometry_set = self.define_geometry(inputs)
+        key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))
+
+        # Propulsion state, part of the cache key since the base geometry_set only
+        # describes the wing and HTP planform
+        engine_count = int(float(inputs["data:geometry:propulsion:engine:count"]))
+        engine_config = float(inputs["data:geometry:propulsion:engine:layout"])
+        engine_rpm = float(inputs["data:propulsion:max_rpm"])
+        propeller_diameter = float(inputs["data:geometry:propeller:diameter"])
+        nac_length = float(inputs["data:geometry:propulsion:nacelle:length"])
+        if engine_config != 1.0:
+            y_ratio_key = (0.0,)
+        else:
+            y_ratio_key = tuple(
+                np.around(
+                    np.atleast_1d(inputs["data:geometry:propulsion:engine:y_ratio"]).astype(float),
+                    6,
+                ).tolist()
+            )
+
+        # Same derivation and rounding as in _compute_wing_rotor
+        atm = Atmosphere(altitude, altitude_in_feet=False)
+        engine_rps = engine_rpm / 60.0
+        thrust_coefficient = round(
+            float(
+                thrust / engine_count / (atm.density * engine_rps**2.0 * propeller_diameter**4.0)
+            ),
+            5,
+        )
+        power_coefficient = round(
+            float(power / engine_count / (atm.density * engine_rps**3.0 * propeller_diameter**5.0)),
+            5,
+        )
+
+        condition_values = [
+            round(float(altitude), 1),
+            mach,
+            round(float(aoa_angle), 2),
+            thrust_coefficient,
+            power_coefficient,
+            engine_count,
+            engine_config,
+            round(engine_rpm, 1),
+            round(propeller_diameter, 3),
+            round(nac_length, 3),
+            y_ratio_key,
+        ]
+
+        condition_key = str(dict(zip(WING_ROTOR_CONDITION_LABELS, condition_values)))
+
+        return self.get_or_compute_cached(
+            key,
+            ROTOR_CACHE_NAMESPACE,
+            condition_key,
+            lambda: self._compute_wing_rotor(
+                inputs, outputs, altitude, mach, aoa_angle, thrust, power
+            ),
+        )
+
+    def _compute_wing_rotor(self, inputs, outputs, altitude, mach, aoa_angle, thrust, power):
+        """
         Function that computes in OpenVSP environment the wing with a rotor and returns the
         different aerodynamic parameters.
 
@@ -1218,13 +1444,22 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
         @param power: total aircraft power for computation of power coefficient (will be divided
         by engine count)
         @return: wing dictionary including aero parameters as keys: y_vector, cl_vector, cd_vector,
-        cm_vector, cl, cdi, cm, coeff_e
+        cm_vector, cl, cdi, cm, coef_e
         """
 
         # TODO : Check for rules that would allow the scaling of these results i.e, same D/span
         #  gives same results...
         # STEP 1/XX - DEFINE OR CALCULATE INPUT DATA FOR AERODYNAMIC EVALUATION ####################
         ############################################################################################
+
+        _LOGGER.info(
+            "Computing OpenVSP wing+rotor for altitude=%s, mach=%s, aoa=%s, thrust=%s, power=%s",
+            altitude,
+            mach,
+            aoa_angle,
+            thrust,
+            power,
+        )
 
         # Get inputs (and calculate missing ones)
         s_ref_wing = float(inputs["data:geometry:wing:area"])
@@ -1578,7 +1813,7 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
             "cl": cl_wing,
             "cdi": cdi_wing,
             "cm": cm_wing,
-            "coeff_e": wing_e,
+            "coef_e": wing_e,
             "ct": thrust_coefficient,
         }
         return wing_rotor

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -512,11 +512,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
             condition_key,
             lambda: self._compute_aero(inputs, outputs, altitude, mach, aoa_angle, comp_opt),
         )
-        # The "ac" option returns a (wing, htp, aircraft) tuple, which a JSON
-        # save/load round-trip of the cache turns into a list. Normalize back so
-        # the return type does not depend on where the result came from.
-        if comp_opt == "ac" and isinstance(result, list):
-            result = tuple(result)
+
         return result
 
     def _compute_aero(self, inputs, outputs, altitude, mach, aoa_angle, comp_opt="wing"):

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -53,11 +53,9 @@ VSPAERO_EXE_NAME = "vspaero.exe"
 
 # Sub-dictionary names used inside a geometry cache entry, next to the mach-keyed results under
 # OpenVSP.
-RAW_AERO_CACHE_NAMESPACE = "raw_aero"
+CLEAN_AERO_CACHE_NAMESPACE = "clean_aero"
 WING_ROTOR_CACHE_NAMESPACE = "wing_rotor"
-# Iterative solves (e.g. a trim/AoA search) tend to call compute_aero / compute_wing_rotor
-# several times with AoA values that only differ by convergence noise (a few hundredths of a
-# degree). Snapping the requested AoA onto an already-cached nearby value.
+# Snapping the requested AoA onto an already-cached nearby value due to small result variation.
 AOA_SNAP_TOLERANCE_DEG = 0.05
 WING_ROTOR_CONDITION_LABELS = [
     "altitude",
@@ -152,26 +150,18 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
                         # save_cache() writes the in-memory cache back at exit.
                         entry = cls._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
 
-                        is_legacy_cache = "vlm" not in value and "openvsp" not in value
-                        if is_legacy_cache:
-                            entry["openvsp"] = value
-                        else:
-                            if value.get("openvsp"):
-                                entry["openvsp"] = value["openvsp"]
+                        if value.get("openvsp"):
+                            entry["openvsp"] = value["openvsp"]
 
-                            if value.get("vlm"):
-                                entry["vlm"] = value["vlm"]
+                        if value.get("vlm"):
+                            entry["vlm"] = value["vlm"]
 
                         no_openvsp_cache = False
 
         if no_openvsp_cache:
-            _LOGGER.info("No existing OpenVSP cache found in %s, starting empty.", search_folder)
+            _LOGGER.info("No existing OpenVSP cache, starting empty.")
         else:
-            _LOGGER.info(
-                "Loaded OpenVSP cache from %s (%d geometry entries).",
-                search_folder,
-                len(cls._cache),
-            )
+            _LOGGER.info("Loading OpenVSP cache (%d geometry entries).", len(cls._cache))
 
     @classmethod
     def save_cache(
@@ -188,7 +178,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
              Ignored unless `file_name` is given.
         :param file_name: cache file name to use together with `folder_path`.
         """
-        if folder_path is not None and file_name:
+        if folder_path and file_name:
             path = cls._resolve_cache_path(folder_path, file_name)
         elif cls._cache_file is not None:
             path = Path(cls._cache_file)
@@ -363,7 +353,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         """
 
         # Fix mach number of digits to consider similar results
-        mach = round(float(mach) * 1e3) / 1e3
+        mach = round(mach.item(), 3)
 
         # Get inputs necessary to define global geometry
         s_ref_wing, area_ratio, geometry_set = self.define_geometry(inputs)
@@ -492,10 +482,6 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         if not use_cache:
             return self._compute_aero(inputs, outputs, altitude, mach, aoa_angle, comp_opt)
 
-        # Fix mach number of digits to consider similar results (same rounding as
-        # compute_aero_coeff)
-        mach = round(float(mach) * 1e3) / 1e3
-
         _, _, geometry_set = self.define_geometry(inputs)
         key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))
         condition_values = [
@@ -506,7 +492,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         ]
 
         self.register_geometry(key)
-        namespace_cache = self._cache[key]["openvsp"].setdefault(RAW_AERO_CACHE_NAMESPACE, {})
+        namespace_cache = self._cache[key]["openvsp"].setdefault(CLEAN_AERO_CACHE_NAMESPACE, {})
         clean_aero_condition = dict(zip(RAW_AERO_CONDITION_LABELS, condition_values))
         clean_aero_condition["AoA"] = self._snap_to_cached_aoa(
             namespace_cache, clean_aero_condition
@@ -516,7 +502,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         result = self.get_or_compute_cached(
             key,
-            RAW_AERO_CACHE_NAMESPACE,
+            CLEAN_AERO_CACHE_NAMESPACE,
             condition_key,
             lambda: self._compute_aero(inputs, outputs, altitude, mach, aoa_angle, comp_opt),
         )
@@ -1216,7 +1202,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         any change.
 
         :param key: geometry cache key, as built from GEOMETRY_SET_LABELS
-        :param namespace: sub-dictionary name (e.g. RAW_AERO_CACHE_NAMESPACE)
+        :param namespace: sub-dictionary name (e.g. CLEAN_AERO_CACHE_NAMESPACE)
         :param condition_key: string key identifying the run conditions
         :param compute_fn: zero-argument callable performing the actual (costly)
             computation, only invoked on a cache miss
@@ -1444,9 +1430,6 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
 
         Parameters and return value are identical to :meth:`_compute_wing_rotor`.
         """
-        # Fix mach number of digits to consider similar results (same rounding as
-        # compute_aero_coeff)
-        mach = round(float(mach) * 1e3) / 1e3
 
         _, _, geometry_set = self.define_geometry(inputs)
         key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -213,7 +213,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
 
         # Prevent reloading the cache if it's already been loaded from the same path.
         if OpenVSPSimpleGeometry._cache_loaded_from is None:
-            OpenVSPSimpleGeometry.load_cache(folder_path)
+            OpenVSPSimpleGeometry.load_cache(resolved)
 
         # Register the atexit callback process only once, since multiple instances of this
         # component may be created. Only register it when `result_file_name` is set.

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -352,8 +352,7 @@ class OpenVSPSimpleGeometry(ExternalCodeComp):
         cl_0_htp,  cl_aoa_htp, cl_alpha_htp, cl_alpha_htp_isolated, y_vector_htp, cl_vector_htp,
         coef_k_htp parameters.
         """
-        # initialize
-        results = [None] * 17
+
         # Fix mach number of digits to consider similar results
         mach = round(float(mach) * 1e3) / 1e3
 

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp3201/__init__.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp3201/__init__.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/external/openvsp/resources/__init__.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/resources/__init__.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastga/models/aerodynamics/external/vlm/compute_aero.py
+++ b/src/fastga/models/aerodynamics/external/vlm/compute_aero.py
@@ -309,14 +309,14 @@ class _ComputeAeroVLM(VLMSimpleGeometry):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
             cl_0_htp,
             cl_X_htp,
             cl_alpha_htp,
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coef_k_htp,
+            coeff_k_htp,
         ) = self.compute_aero_coeff(inputs, altitude, mach, input_aoa)
 
         if self.options["low_speed_aero"]:
@@ -336,7 +336,7 @@ class _ComputeAeroVLM(VLMSimpleGeometry):
             outputs["data:aerodynamics:wing:low_speed:Y_vector"] = y_vector_wing
             outputs["data:aerodynamics:wing:low_speed:CL_vector"] = cl_vector_wing
             outputs["data:aerodynamics:wing:low_speed:chord_vector"] = chord_vector_wing
-            outputs["data:aerodynamics:wing:low_speed:induced_drag_coefficient"] = coef_k_wing
+            outputs["data:aerodynamics:wing:low_speed:induced_drag_coefficient"] = coeff_k_wing
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL0"] = cl_0_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL_ref"] = cl_X_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL_alpha"] = cl_alpha_htp
@@ -346,21 +346,21 @@ class _ComputeAeroVLM(VLMSimpleGeometry):
             outputs["data:aerodynamics:horizontal_tail:low_speed:Y_vector"] = y_vector_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:CL_vector"] = cl_vector_htp
             outputs["data:aerodynamics:horizontal_tail:low_speed:induced_drag_coefficient"] = (
-                coef_k_htp
+                coeff_k_htp
             )
         else:
             outputs["data:aerodynamics:wing:cruise:CL0_clean"] = cl_0_wing
             outputs["data:aerodynamics:wing:cruise:CL_ref"] = cl_ref_wing
             outputs["data:aerodynamics:wing:cruise:CL_alpha"] = cl_alpha_wing
             outputs["data:aerodynamics:wing:cruise:CM0_clean"] = cm_0_wing
-            outputs["data:aerodynamics:wing:cruise:induced_drag_coefficient"] = coef_k_wing
+            outputs["data:aerodynamics:wing:cruise:induced_drag_coefficient"] = coeff_k_wing
             outputs["data:aerodynamics:horizontal_tail:cruise:CL0"] = cl_0_htp
             outputs["data:aerodynamics:horizontal_tail:cruise:CL_alpha"] = cl_alpha_htp
             outputs["data:aerodynamics:horizontal_tail:cruise:CL_alpha_isolated"] = (
                 cl_alpha_htp_isolated
             )
             outputs["data:aerodynamics:horizontal_tail:cruise:induced_drag_coefficient"] = (
-                coef_k_htp
+                coeff_k_htp
             )
             if self.options["compute_mach_interpolation"]:
                 outputs["data:aerodynamics:aircraft:mach_interpolation:mach_vector"] = mach_interp

--- a/src/fastga/models/aerodynamics/external/vlm/vlm.py
+++ b/src/fastga/models/aerodynamics/external/vlm/vlm.py
@@ -90,7 +90,6 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         cls._cache_loaded_from = str(search_folder)
 
         no_vlm_cache = True
-
         for file in search_folder.glob("*.json"):
             try:
                 with open(file, "r", encoding="utf-8") as cache_fp:
@@ -113,8 +112,17 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                         # be wiped out (replaced by an empty dict) when this class's
                         # save_cache() writes the in-memory cache back at exit.
                         entry = cls._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
-                        entry["vlm"] = value.get("vlm", value)
-                        entry["openvsp"] = value.get("openvsp", entry["openvsp"])
+
+                        is_legacy_cache = "vlm" not in value and "openvsp" not in value
+                        if is_legacy_cache:
+                            entry["vlm"] = value
+                        else:
+                            if value.get("openvsp"):
+                                entry["openvsp"] = value["openvsp"]
+
+                            if value.get("vlm"):
+                                entry["vlm"] = value["vlm"]
+
                         no_vlm_cache = False
 
         if no_vlm_cache:
@@ -326,9 +334,9 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         @param altitude: altitude for aerodynamic calculation in meters
         @param mach: air speed expressed in mach
         @param aoa_angle: air speed angle of attack with respect to aircraft
-        @return: cl_0_wing, cl_alpha_wing, cm_0_wing, y_vector_wing, cl_vector_wing, coef_k_wing,
+        @return: cl_0_wing, cl_alpha_wing, cm_0_wing, y_vector_wing, cl_vector_wing, coeff_k_wing,
         cl_0_htp, cl_X_htp, cl_alpha_htp, cl_alpha_htp_isolated, y_vector_htp, cl_vector_htp,
-        coef_k_htp parameters.
+        coeff_k_htp parameters.
 
                 ^
               y |                Points defining the panel
@@ -438,7 +446,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                 y_vector_wing,
                 cl_vector_wing,
                 chord_vector_wing,
-                coef_k_wing,
+                coeff_k_wing,
             ) = self.post_processing_wing(
                 width_max,
                 span_wing,
@@ -457,7 +465,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                 cl_0_htp,
                 cl_aoa_htp,
                 cl_alpha_htp,
-                coef_k_htp,
+                coeff_k_htp,
                 y_vector_htp,
                 cl_vector_htp,
             ) = self.post_processing_htp_ac(
@@ -496,14 +504,14 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                 np.array(y_vector_wing).tolist(),
                 np.array(cl_vector_wing).tolist(),
                 np.array(chord_vector_wing).tolist(),
-                float(coef_k_wing),
+                float(coeff_k_wing),
                 float(cl_0_htp),
                 float(cl_aoa_htp),
                 float(cl_alpha_htp),
                 float(cl_alpha_htp_isolated),
                 np.array(y_vector_htp).tolist(),
                 np.array(cl_vector_htp).tolist(),
-                float(coef_k_htp),
+                float(coeff_k_htp),
                 float(sref_wing),
                 float(area_ratio),
             ]
@@ -520,14 +528,14 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                 y_vector_wing,
                 cl_vector_wing,
                 chord_vector_wing,
-                coef_k_wing,
+                coeff_k_wing,
                 cl_0_htp,
                 cl_aoa_htp,
                 cl_alpha_htp,
                 cl_alpha_htp_isolated,
                 y_vector_htp,
                 cl_vector_htp,
-                coef_k_htp,
+                coeff_k_htp,
             ) = self.read_value_from_data(key, mach, sref_wing, area_ratio)
 
         return (
@@ -538,14 +546,14 @@ class VLMSimpleGeometry(om.ExplicitComponent):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
             cl_0_htp,
             cl_aoa_htp,
             cl_alpha_htp,
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coef_k_htp,
+            coeff_k_htp,
         )
 
     def compute_wing(
@@ -567,7 +575,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         :param flaps_angle: flaps angle in Deg (default=0.0: i.e. no deflection)
         :param use_airfoil: adds the camber line coordinates of the selected airfoil (default=True)
         :return: wing dictionary including aero parameters as keys: y_vector, cl_vector, cd_vector,
-        cm_vector, cl, cdi, cm, coef_e
+        cm_vector, cl, cdi, cm, coeff_e
         """
 
         # Generate geometries
@@ -633,7 +641,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
             "cl": cl_wing,
             "cdi": cdi_wing,
             "cm": cm_wing,
-            "coef_e": wing_e,
+            "coeff_e": wing_e,
         }
 
         return wing
@@ -655,7 +663,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         :param aoa_angle: air speed angle of attack with respect to aircraft (degree).
         :param use_airfoil: adds the camber line coordinates of the selected airfoil (default=True).
         :return: htp dictionary including aero parameters as keys: y_vector, cl_vector, cd_vector,
-        cm_vector, cl, cdi, cm, coef_e.
+        cm_vector, cl, cdi, cm, coeff_e.
         """
 
         # Generate geometries
@@ -714,7 +722,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
             "cl": cl_htp,
             "cdi": cdi_htp,
             "cm": cm_htp,
-            "coef_e": htp_e,
+            "coeff_e": htp_e,
         }
 
         return htp
@@ -765,7 +773,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         htp = self.compute_htp(inputs, altitude, mach, aoa_angle_corrected, use_airfoil=True)
 
         # Save results at aircraft level
-        aircraft = {"cl": wing["cl"] + htp["cl"], "cd0": None, "cdi": None, "coef_e": None}
+        aircraft = {"cl": wing["cl"] + htp["cl"], "cd0": None, "cdi": None, "coeff_e": None}
 
         return wing, htp, aircraft
 
@@ -1202,15 +1210,15 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         cdp_foil = self._interpolate_cdp(cl_wing_airfoil, cdp_wing_airfoil, cl_x_wing)
         # Mach correction
         if mach <= 0.4:
-            coef_e = wing_aoa["coef_e"]
+            coeff_e = wing_aoa["coeff_e"]
         else:
-            coef_e = wing_aoa["coef_e"] * (-0.001521 * ((mach - 0.05) / 0.3 - 1) ** 10.82 + 1)
-        cdi = cl_x_wing**2 / (np.pi * aspect_ratio_wing * coef_e) + cdp_foil
-        coef_e = wing_aoa["cl"] ** 2 / (np.pi * aspect_ratio_wing * cdi)
+            coeff_e = wing_aoa["coeff_e"] * (-0.001521 * ((mach - 0.05) / 0.3 - 1) ** 10.82 + 1)
+        cdi = cl_x_wing**2 / (np.pi * aspect_ratio_wing * coeff_e) + cdp_foil
+        coeff_e = wing_aoa["cl"] ** 2 / (np.pi * aspect_ratio_wing * cdi)
         # Fuselage correction
         k_fus = 1 - 2 * (width_max / span_wing) ** 2
-        coef_e = float(coef_e * k_fus)
-        coef_k_wing = float(1.0 / (np.pi * aspect_ratio_wing * coef_e))
+        coeff_e = float(coeff_e * k_fus)
+        coeff_k_wing = float(1.0 / (np.pi * aspect_ratio_wing * coeff_e))
 
         return (
             beta,
@@ -1221,7 +1229,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
         )
 
     def post_processing_htp_ac(
@@ -1257,11 +1265,11 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         cdp_foil = self._interpolate_cdp(cl_htp_airfoil, cdp_htp_airfoil, htp_aoa["cl"] / beta)
         # Mach correction
         if mach <= 0.4:
-            coef_e = htp_aoa["coef_e"]
+            coeff_e = htp_aoa["coeff_e"]
         else:
-            coef_e = htp_aoa["coef_e"] * (-0.001521 * ((mach - 0.05) / 0.3 - 1) ** 10.82 + 1)
-        cdi = (htp_aoa["cl"] / beta) ** 2 / (np.pi * aspect_ratio_htp * coef_e) + cdp_foil
-        coef_k_htp = float(cdi / cl_aoa_htp**2 * area_ratio)
+            coeff_e = htp_aoa["coeff_e"] * (-0.001521 * ((mach - 0.05) / 0.3 - 1) ** 10.82 + 1)
+        cdi = (htp_aoa["cl"] / beta) ** 2 / (np.pi * aspect_ratio_htp * coeff_e) + cdp_foil
+        coeff_k_htp = float(cdi / cl_aoa_htp**2 * area_ratio)
         y_vector_htp = htp_aoa["y_vector"]
         cl_vector_htp = (np.array(htp_aoa["cl_vector"]) / beta * area_ratio).tolist()
 
@@ -1269,7 +1277,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
             cl_0_htp,
             cl_aoa_htp,
             cl_alpha_htp,
-            coef_k_htp,
+            coeff_k_htp,
             y_vector_htp,
             cl_vector_htp,
         )
@@ -1286,25 +1294,25 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         :return: existing data
         """
         data = self._cache[key]["vlm"][str(mach)]
-        saved_area_wing = data.get("saved_ref_area")
-        saved_area_ratio = data.get("area_ratio")
-        cl_0_wing = data.get("cl_0_wing")
-        cl_x_wing = data.get("cl_X_wing")
-        cl_alpha_wing = data.get("cl_alpha_wing")
-        cm_0_wing = data.get("cm_0_wing")
-        y_vector_wing = np.array(data.get("y_vector_wing")) * np.sqrt(sref_wing / saved_area_wing)
-        cl_vector_wing = np.array(data.get("cl_vector_wing"))
-        chord_vector_wing = np.array(data.get("chord_vector_wing")) * np.sqrt(
+        saved_area_wing = data["saved_ref_area"]
+        saved_area_ratio = data["area_ratio"]
+        cl_0_wing = data["cl_0_wing"]
+        cl_x_wing = data["cl_X_wing"]
+        cl_alpha_wing = data["cl_alpha_wing"]
+        cm_0_wing = data["cm_0_wing"]
+        y_vector_wing = np.array(data["y_vector_wing"]) * np.sqrt(sref_wing / saved_area_wing)
+        cl_vector_wing = np.array(data["cl_vector_wing"])
+        chord_vector_wing = np.array(data["chord_vector_wing"]) * np.sqrt(
             sref_wing / saved_area_wing
         )
-        coef_k_wing = data.get("coef_k_wing")
-        cl_0_htp = data.get("cl_0_htp") * (area_ratio / saved_area_ratio)
-        cl_aoa_htp = data.get("cl_X_htp") * (area_ratio / saved_area_ratio)
-        cl_alpha_htp = data.get("cl_alpha_htp") * (area_ratio / saved_area_ratio)
-        cl_alpha_htp_isolated = data.get("cl_alpha_htp_isolated") * (area_ratio / saved_area_ratio)
-        y_vector_htp = np.array(data.get("y_vector_htp"))
-        cl_vector_htp = np.array(data.get("cl_vector_htp"))
-        coef_k_htp = data.get("coef_k_htp") * (area_ratio / saved_area_ratio)
+        coeff_k_wing = data["coeff_k_wing"]
+        cl_0_htp = data["cl_0_htp"] * (area_ratio / saved_area_ratio)
+        cl_aoa_htp = data["cl_X_htp"] * (area_ratio / saved_area_ratio)
+        cl_alpha_htp = data["cl_alpha_htp"] * (area_ratio / saved_area_ratio)
+        cl_alpha_htp_isolated = data["cl_alpha_htp_isolated"] * (area_ratio / saved_area_ratio)
+        y_vector_htp = np.array(data["y_vector_htp"])
+        cl_vector_htp = np.array(data["cl_vector_htp"])
+        coeff_k_htp = data["coeff_k_htp"] * (area_ratio / saved_area_ratio)
 
         return (
             cl_0_wing,
@@ -1314,14 +1322,14 @@ class VLMSimpleGeometry(om.ExplicitComponent):
             y_vector_wing,
             cl_vector_wing,
             chord_vector_wing,
-            coef_k_wing,
+            coeff_k_wing,
             cl_0_htp,
             cl_aoa_htp,
             cl_alpha_htp,
             cl_alpha_htp_isolated,
             y_vector_htp,
             cl_vector_htp,
-            coef_k_htp,
+            coeff_k_htp,
         )
 
     @staticmethod

--- a/src/fastga/models/aerodynamics/external/vlm/vlm.py
+++ b/src/fastga/models/aerodynamics/external/vlm/vlm.py
@@ -107,7 +107,14 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                     if all(label in key for label in GEOMETRY_SET_LABELS) and isinstance(
                         value, dict
                     ):
-                        cls._cache[key] = value
+                        # Preserve both branches from the file (not just "vlm"): this class
+                        # only ever populates/overwrites the "vlm" branch during a run, so
+                        # the "openvsp" branch must be carried through untouched or it would
+                        # be wiped out (replaced by an empty dict) when this class's
+                        # save_cache() writes the in-memory cache back at exit.
+                        entry = cls._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
+                        entry["vlm"] = value.get("vlm", value)
+                        entry["openvsp"] = value.get("openvsp", entry["openvsp"])
                         no_vlm_cache = False
 
         if no_vlm_cache:
@@ -172,7 +179,9 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         # component may be created. Only register it when `result_file_name` is set.
         if not VLMSimpleGeometry._atexit_registered:
             if resolved is not None and file_name:
-                atexit.register(VLMSimpleGeometry.save_cache)
+                atexit.register(
+                    VLMSimpleGeometry.save_cache, folder_path=folder_path, file_name=file_name
+                )
             VLMSimpleGeometry._atexit_registered = True
 
     def __init__(self, **kwargs):
@@ -380,7 +389,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
         key = str(dict(zip(GEOMETRY_SET_LABELS, geometry_set)))
 
         # Compute results if not already in cache, else retrieve them and adapt to new area ratio
-        if self._cache.get(key) is None or self._cache[key].get(str(mach)) is None:
+        if self._cache.get(key) is None or self._cache[key]["vlm"].get(str(mach)) is None:
             self.register_geometry(key)
 
             # Compute wing alone @ 0°/X° angle of attack
@@ -1139,11 +1148,11 @@ class VLMSimpleGeometry(om.ExplicitComponent):
 
     def register_geometry(self, key):
         """Register the geometry set as a key in the in-memory cache."""
-        self._cache.setdefault(key, {})
+        self._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
 
     def save_results(self, key, results, mach):
         """Store VLM results in the in-memory cache."""
-        self._cache[key][str(mach)] = dict(zip(RESULT_LABELS, results))
+        self._cache[key]["vlm"][str(mach)] = dict(zip(RESULT_LABELS, results))
 
     def post_processing_wing(
         self,
@@ -1276,7 +1285,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
 
         :return: existing data
         """
-        data = self._cache[key][str(mach)]
+        data = self._cache[key]["vlm"][str(mach)]
         saved_area_wing = data.get("saved_ref_area")
         saved_area_ratio = data.get("area_ratio")
         cl_0_wing = data.get("cl_0_wing")

--- a/src/fastga/models/aerodynamics/external/vlm/vlm.py
+++ b/src/fastga/models/aerodynamics/external/vlm/vlm.py
@@ -113,24 +113,18 @@ class VLMSimpleGeometry(om.ExplicitComponent):
                         # save_cache() writes the in-memory cache back at exit.
                         entry = cls._cache.setdefault(key, {"vlm": {}, "openvsp": {}})
 
-                        is_legacy_cache = "vlm" not in value and "openvsp" not in value
-                        if is_legacy_cache:
-                            entry["vlm"] = value
-                        else:
-                            if value.get("openvsp"):
-                                entry["openvsp"] = value["openvsp"]
+                        if value.get("openvsp"):
+                            entry["openvsp"] = value["openvsp"]
 
-                            if value.get("vlm"):
-                                entry["vlm"] = value["vlm"]
+                        if value.get("vlm"):
+                            entry["vlm"] = value["vlm"]
 
                         no_vlm_cache = False
 
         if no_vlm_cache:
-            _LOGGER.info("No existing VLM cache found in %s, starting empty.", search_folder)
+            _LOGGER.info("No existing VLM cache found, starting empty.")
         else:
-            _LOGGER.info(
-                "Loaded VLM cache from %s (%d geometry entries).", search_folder, len(cls._cache)
-            )
+            _LOGGER.info("Loading VLM cache (%d geometry entries).", len(cls._cache))
 
     @classmethod
     def save_cache(
@@ -147,7 +141,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
              Ignored unless `file_name` is given.
         :param file_name: cache file name to use together with `folder_path`.
         """
-        if folder_path is not None and file_name:
+        if folder_path and file_name:
             path = cls._resolve_cache_path(folder_path, file_name)
         elif cls._cache_file is not None:
             path = Path(cls._cache_file)

--- a/src/fastga/models/aerodynamics/external/vlm/vlm.py
+++ b/src/fastga/models/aerodynamics/external/vlm/vlm.py
@@ -25,42 +25,17 @@ import openmdao.api as om
 from stdatm import Atmosphere
 
 from fastga.models.geometry.profiles.get_profile import get_profile
-from ...constants import SPAN_MESH_POINT, POLAR_POINT_COUNT, MACH_NB_PTS
+from ...constants import (
+    SPAN_MESH_POINT,
+    POLAR_POINT_COUNT,
+    MACH_NB_PTS,
+    GEOMETRY_SET_LABELS,
+    RESULT_LABELS,
+)
 
 DEFAULT_NX = 19
 DEFAULT_NY1 = 3
 DEFAULT_NY2 = 14
-
-GEOMETRY_SET_LABELS = [
-    "sweep25_wing",
-    "taper_ratio_wing",
-    "aspect_ratio_wing",
-    "dihedral_angle_wing",
-    "twist_angle_wing",
-    "sweep25_htp",
-    "taper_ratio_htp",
-    "aspect_ratio_htp",
-]
-
-VLM_RESULT_LABELS = [
-    "cl_0_wing",
-    "cl_X_wing",
-    "cl_alpha_wing",
-    "cm_0_wing",
-    "y_vector_wing",
-    "cl_vector_wing",
-    "chord_vector_wing",
-    "coef_k_wing",
-    "cl_0_htp",
-    "cl_X_htp",
-    "cl_alpha_htp",
-    "cl_alpha_htp_isolated",
-    "y_vector_htp",
-    "cl_vector_htp",
-    "coef_k_htp",
-    "saved_ref_area",
-    "area_ratio",
-]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1168,7 +1143,7 @@ class VLMSimpleGeometry(om.ExplicitComponent):
 
     def save_results(self, key, results, mach):
         """Store VLM results in the in-memory cache."""
-        self._cache[key][str(mach)] = dict(zip(VLM_RESULT_LABELS, results))
+        self._cache[key][str(mach)] = dict(zip(RESULT_LABELS, results))
 
     def post_processing_wing(
         self,


### PR DESCRIPTION
This PR replaces temporary CSV I/O with an in-memory cache in `OpenVSPSimpleGeometry` and `OpenVSPSimpleGeometryDP` to eliminate read/write overhead.