### PR TITLE
Propulsion ID rework + remove of direct OpenMDAO imports

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,111 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import contextlib
+import importlib.metadata as importlib_metadata
+from typing import ClassVar
+from unittest.mock import Mock
+
+import pytest
+import wrapt
+
+from fastoad.module_management._plugins import MODEL_PLUGIN_ID, FastoadLoader
+
+
+@pytest.fixture
+def with_dummy_plugin_1():
+    """
+    Reduces plugin list to dummy-dist-1 with plugin test_plugin_1
+    (one configuration file, no models, notebook folder, no source data files).
+
+    Any previous state of plugins is restored during teardown.
+    """
+    _setup()
+    dummy_dist_1 = Mock(importlib_metadata.Distribution)
+    dummy_dist_1.name = "dummy-dist-1"
+    new_entry_points = [
+        importlib_metadata.EntryPoint(
+            name="test_plugin_1",
+            value="tests.dummy_plugins.dummy_plugin_1",
+            group=MODEL_PLUGIN_ID,
+        )
+    ]
+    new_entry_points[0].dist = dummy_dist_1
+    _update_entry_map(new_entry_points)
+    yield
+    _teardown()
+
+
+def _update_entry_map(new_plugin_entry_points: list[importlib_metadata.EntryPoint]):
+    """
+    Modified plugin entry_points of FAST-OAD distribution.
+
+    This is done by replacing the entry_points property of Distribution class
+
+    :param new_plugin_entry_points:
+    """
+    BypassEntryPointReading.entry_points = new_plugin_entry_points
+    BypassEntryPointReading.active = True
+    FastoadLoader._loaded = False
+
+
+def _setup():
+    MakeEntryPointMutable.active = True
+
+
+def _teardown():
+    MakeEntryPointMutable.active = False
+    BypassEntryPointReading.active = False
+    FastoadLoader._loaded = False
+
+
+# Monkey-patching using wrapt module ###########################################
+
+
+def _BypassEntryPointReading_enabled():  # noqa: N802 more readable with camelcase
+    return BypassEntryPointReading.active
+
+
+class BypassEntryPointReading:
+    active: bool = False
+    entry_points: ClassVar[list] = []
+
+    @wrapt.decorator(enabled=_BypassEntryPointReading_enabled)
+    def __call__(self, wrapped, instance, args, kwargs):
+        if kwargs.get("group") == MODEL_PLUGIN_ID:
+            return self.entry_points
+        return wrapped(*args, **kwargs)
+
+
+importlib_metadata.entry_points = BypassEntryPointReading()(importlib_metadata.entry_points)
+
+
+def _MakeEntryPointMutable_enabled():  # noqa: N802 more readable with camelcase
+    return MakeEntryPointMutable.active
+
+
+class MakeEntryPointMutable:
+    active = True
+
+    @classmethod
+    def _enabled(cls):
+        return cls.active
+
+    @wrapt.decorator(enabled=_MakeEntryPointMutable_enabled)
+    def __call__(self, wrapped, instance, args, kwargs):
+        with contextlib.suppress(AttributeError):
+            delattr(wrapped, "__setattr__")
+        return wrapped(*args, **kwargs)
+
+
+importlib_metadata.EntryPoint = MakeEntryPointMutable()(importlib_metadata.EntryPoint)

--- a/src/fastga/models/aerodynamics/aero_center.py
+++ b/src/fastga/models/aerodynamics/aero_center.py
@@ -14,11 +14,11 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 from stdatm import Atmosphere
 
 
-class ComputeAeroCenter(ExplicitComponent):
+class ComputeAeroCenter(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Aerodynamic center estimation."""
 

--- a/src/fastga/models/aerodynamics/aerodynamics.py
+++ b/src/fastga/models/aerodynamics/aerodynamics.py
@@ -33,7 +33,7 @@ class Aerodynamics(om.Group):
 
     def initialize(self):
         """Definition of the options for the group."""
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
         self.options.declare("use_openvsp", default=False, types=bool)
         self.options.declare("compute_mach_interpolation", default=False, types=bool)
         self.options.declare("compute_slipstream_low_speed", default=False, types=bool)

--- a/src/fastga/models/aerodynamics/aerodynamics.py
+++ b/src/fastga/models/aerodynamics/aerodynamics.py
@@ -33,7 +33,7 @@ class Aerodynamics(om.Group):
 
     def initialize(self):
         """Definition of the options for the group."""
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("use_openvsp", default=False, types=bool)
         self.options.declare("compute_mach_interpolation", default=False, types=bool)
         self.options.declare("compute_slipstream_low_speed", default=False, types=bool)

--- a/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
@@ -45,7 +45,7 @@ class AerodynamicsHighSpeed(om.Group):
     """Models for high speed aerodynamics."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("use_openvsp", default=False, types=bool)
         self.options.declare("compute_mach_interpolation", default=False, types=bool)
         self.options.declare("compute_slipstream", default=False, types=bool)

--- a/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
@@ -12,7 +12,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from openmdao.core.group import Group
+import openmdao.api as om
 
 import fastoad.api as oad
 from fastoad.module_management.constants import ModelDomain
@@ -41,7 +41,7 @@ from .constants import (
 
 
 @oad.RegisterOpenMDAOSystem("fastga.aerodynamics.highspeed.legacy", domain=ModelDomain.AERODYNAMICS)
-class AerodynamicsHighSpeed(Group):
+class AerodynamicsHighSpeed(om.Group):
     """Models for high speed aerodynamics."""
 
     def initialize(self):

--- a/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_high_speed.py
@@ -45,7 +45,7 @@ class AerodynamicsHighSpeed(Group):
     """Models for high speed aerodynamics."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
         self.options.declare("use_openvsp", default=False, types=bool)
         self.options.declare("compute_mach_interpolation", default=False, types=bool)
         self.options.declare("compute_slipstream", default=False, types=bool)

--- a/src/fastga/models/aerodynamics/aerodynamics_low_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_low_speed.py
@@ -47,7 +47,7 @@ class AerodynamicsLowSpeed(om.Group):
     """Models for low speed aerodynamics."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
         self.options.declare("use_openvsp", default=False, types=bool)
         self.options.declare("compute_slipstream", default=False, types=bool)
         self.options.declare("result_folder_path", default="", types=str)

--- a/src/fastga/models/aerodynamics/aerodynamics_low_speed.py
+++ b/src/fastga/models/aerodynamics/aerodynamics_low_speed.py
@@ -47,7 +47,7 @@ class AerodynamicsLowSpeed(om.Group):
     """Models for low speed aerodynamics."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("use_openvsp", default=False, types=bool)
         self.options.declare("compute_slipstream", default=False, types=bool)
         self.options.declare("result_folder_path", default="", types=str)

--- a/src/fastga/models/aerodynamics/components/cd0.py
+++ b/src/fastga/models/aerodynamics/components/cd0.py
@@ -35,7 +35,7 @@ from ..constants import (
 class Cd0(Group):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
         self.options.declare(
             "wing_airfoil_file", default="naca23012.af", types=str, allow_none=True

--- a/src/fastga/models/aerodynamics/components/cd0.py
+++ b/src/fastga/models/aerodynamics/components/cd0.py
@@ -35,7 +35,7 @@ from ..constants import (
 class Cd0(om.Group):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
         self.options.declare(
             "wing_airfoil_file", default="naca23012.af", types=str, allow_none=True

--- a/src/fastga/models/aerodynamics/components/cd0.py
+++ b/src/fastga/models/aerodynamics/components/cd0.py
@@ -15,8 +15,8 @@ its components.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.group import Group
 
 from ..constants import (
     SUBMODEL_CD0_WING,
@@ -32,7 +32,7 @@ from ..constants import (
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0, "fastga.submodel.aerodynamics.aircraft.cd0.legacy")
-class Cd0(Group):
+class Cd0(om.Group):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
         self.options.declare("propulsion_id", default=None, types=str, allow_none=True)

--- a/src/fastga/models/aerodynamics/components/cd0_fuselage.py
+++ b/src/fastga/models/aerodynamics/components/cd0_fuselage.py
@@ -13,14 +13,14 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ..constants import SUBMODEL_CD0_FUSELAGE
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_FUSELAGE, "fastga.submodel.aerodynamics.fuselage.cd0.legacy")
-class Cd0Fuselage(ExplicitComponent):
+class Cd0Fuselage(om.ExplicitComponent):
     """
     Profile drag estimation for the fuselage
 

--- a/src/fastga/models/aerodynamics/components/cd0_ht.py
+++ b/src/fastga/models/aerodynamics/components/cd0_ht.py
@@ -13,15 +13,15 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from fastga.models.geometry.profiles.get_profile import get_profile
 from ..constants import SUBMODEL_CD0_HT
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_HT, "fastga.submodel.aerodynamics.horizontal_tail.cd0.legacy")
-class Cd0HorizontalTail(ExplicitComponent):
+class Cd0HorizontalTail(om.ExplicitComponent):
     """
     Profile drag estimation for the horizontal tail.
 

--- a/src/fastga/models/aerodynamics/components/cd0_lg.py
+++ b/src/fastga/models/aerodynamics/components/cd0_lg.py
@@ -13,8 +13,8 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ..constants import SUBMODEL_CD0_LANDING_GEAR
 
@@ -22,7 +22,7 @@ from ..constants import SUBMODEL_CD0_LANDING_GEAR
 @oad.RegisterSubmodel(
     SUBMODEL_CD0_LANDING_GEAR, "fastga.submodel.aerodynamics.landing_gear.cd0.legacy"
 )
-class Cd0LandingGear(ExplicitComponent):
+class Cd0LandingGear(om.ExplicitComponent):
     """
     Profile drag estimation for the landing gear
 

--- a/src/fastga/models/aerodynamics/components/cd0_nacelle.py
+++ b/src/fastga/models/aerodynamics/components/cd0_nacelle.py
@@ -15,18 +15,18 @@
 import warnings
 
 import numpy as np
+import openmdao.api as om
+import fastoad.api as oad
 
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
-import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from fastga.models.propulsion.fuel_propulsion.base import FuelEngineSet
 from ..constants import SUBMODEL_CD0_NACELLE
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_NACELLE, "fastga.submodel.aerodynamics.nacelle.cd0.legacy")
-class Cd0Nacelle(ExplicitComponent):
+class Cd0Nacelle(om.ExplicitComponent):
     """
     Profile drag estimation for the engine nacelle
 

--- a/src/fastga/models/aerodynamics/components/cd0_nacelle.py
+++ b/src/fastga/models/aerodynamics/components/cd0_nacelle.py
@@ -22,6 +22,7 @@ import fastoad.api as oad
 from fastoad.module_management._bundle_loader import BundleLoader
 
 from fastga.models.propulsion.fuel_propulsion.base import FuelEngineSet
+from fastga.utils.options_checkers import check_propulsion_id
 from ..constants import SUBMODEL_CD0_NACELLE
 
 
@@ -40,7 +41,7 @@ class Cd0Nacelle(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/aerodynamics/components/cd0_nacelle.py
+++ b/src/fastga/models/aerodynamics/components/cd0_nacelle.py
@@ -40,7 +40,7 @@ class Cd0Nacelle(ExplicitComponent):
 
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/aerodynamics/components/cd0_other.py
+++ b/src/fastga/models/aerodynamics/components/cd0_other.py
@@ -13,14 +13,14 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ..constants import SUBMODEL_CD0_OTHER
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_OTHER, "fastga.submodel.aerodynamics.other.cd0.legacy")
-class Cd0Other(ExplicitComponent):
+class Cd0Other(om.ExplicitComponent):
     """
     Profile drag estimation for miscellaneous items such as cowling, cooling and various component
 

--- a/src/fastga/models/aerodynamics/components/cd0_total.py
+++ b/src/fastga/models/aerodynamics/components/cd0_total.py
@@ -13,14 +13,14 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ..constants import SUBMODEL_CD0_SUM
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_SUM, "fastga.submodel.aerodynamics.sum.cd0.legacy")
-class Cd0Total(ExplicitComponent):
+class Cd0Total(om.ExplicitComponent):
     """
     Profile drag estimation for the whole aircraft. It is the simple sum of all the profile drag
     since every subpart was computed with the wing area as a reference and the interaction are

--- a/src/fastga/models/aerodynamics/components/cd0_vt.py
+++ b/src/fastga/models/aerodynamics/components/cd0_vt.py
@@ -13,14 +13,14 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ..constants import SUBMODEL_CD0_VT
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_VT, "fastga.submodel.aerodynamics.vertical_tail.cd0.legacy")
-class Cd0VerticalTail(ExplicitComponent):
+class Cd0VerticalTail(om.ExplicitComponent):
     """
     Profile drag estimation for the vertical tail
 

--- a/src/fastga/models/aerodynamics/components/cd0_wing.py
+++ b/src/fastga/models/aerodynamics/components/cd0_wing.py
@@ -13,15 +13,15 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from fastga.models.geometry.profiles.get_profile import get_profile
 from ..constants import SUBMODEL_CD0_WING
 
 
 @oad.RegisterSubmodel(SUBMODEL_CD0_WING, "fastga.submodel.aerodynamics.wing.cd0.legacy")
-class Cd0Wing(ExplicitComponent):
+class Cd0Wing(om.ExplicitComponent):
     """
     Profile drag estimation for the wing
 

--- a/src/fastga/models/aerodynamics/components/compute_L_D_max.py
+++ b/src/fastga/models/aerodynamics/components/compute_L_D_max.py
@@ -13,14 +13,14 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ..constants import SUBMODEL_MAX_L_D
 
 
 @oad.RegisterSubmodel(SUBMODEL_MAX_L_D, "fastga.submodel.aerodynamics.aircraft.l_d_max.legacy")
-class ComputeLDMax(ExplicitComponent):
+class ComputeLDMax(om.ExplicitComponent):
     """
     Computes optimal CL/CD aerodynamic performance of the aircraft in cruise conditions.
 

--- a/src/fastga/models/aerodynamics/components/compute_non_equilibrated_polar.py
+++ b/src/fastga/models/aerodynamics/components/compute_non_equilibrated_polar.py
@@ -15,12 +15,12 @@ Computation of the non-equilibrated aircraft polars
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 from fastga.models.aerodynamics.constants import POLAR_POINT_COUNT
 
 
-class ComputeNonEquilibratedPolar(ExplicitComponent):
+class ComputeNonEquilibratedPolar(om.ExplicitComponent):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
 

--- a/src/fastga/models/aerodynamics/components/compute_reynolds.py
+++ b/src/fastga/models/aerodynamics/components/compute_reynolds.py
@@ -16,11 +16,11 @@ Computes Mach number and unitary Reynolds.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 from stdatm import Atmosphere
 
 
-class ComputeUnitReynolds(ExplicitComponent):
+class ComputeUnitReynolds(om.ExplicitComponent):
     """
     Computes the mach number and reynolds number based on inputs and the ISA model.
     """

--- a/src/fastga/models/aerodynamics/components/compute_vn.py
+++ b/src/fastga/models/aerodynamics/components/compute_vn.py
@@ -28,6 +28,8 @@ import fastoad.api as oad
 
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 from ..constants import SUBMODEL_VH
 
 DOMAIN_PTS_NB = 19  # number of (V,n) calculated for the flight domain
@@ -43,7 +45,7 @@ class ComputeVNAndVH(om.Group):
     """Group containing the computation of the V_h and the V-n diagram"""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         propulsion_option = {"propulsion_id": self.options["propulsion_id"]}
@@ -71,7 +73,7 @@ class ComputeVh(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/aerodynamics/components/compute_vn.py
+++ b/src/fastga/models/aerodynamics/components/compute_vn.py
@@ -43,7 +43,7 @@ class ComputeVNAndVH(om.Group):
     """Group containing the computation of the V_h and the V-n diagram"""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         propulsion_option = {"propulsion_id": self.options["propulsion_id"]}
@@ -71,7 +71,7 @@ class ComputeVh(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/aerodynamics/components/fuselage/compute_cn_beta_fuselage.py
+++ b/src/fastga/models/aerodynamics/components/fuselage/compute_cn_beta_fuselage.py
@@ -14,8 +14,8 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 from ...constants import SUBMODEL_CN_BETA_FUSELAGE
 
@@ -23,7 +23,7 @@ from ...constants import SUBMODEL_CN_BETA_FUSELAGE
 @oad.RegisterSubmodel(
     SUBMODEL_CN_BETA_FUSELAGE, "fastga.submodel.aerodynamics.fuselage.yawing_moment_beta.legacy"
 )
-class ComputeCnBetaFuselage(ExplicitComponent):
+class ComputeCnBetaFuselage(om.ExplicitComponent):
     """
     Yawing moment due to side-slip estimation.
 

--- a/src/fastga/models/aerodynamics/compute_polar.py
+++ b/src/fastga/models/aerodynamics/compute_polar.py
@@ -14,8 +14,7 @@ Computation of the aircraft polars
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from openmdao.api import Group
-
+import openmdao.api as om
 import fastoad.api as oad
 from fastoad.module_management.constants import ModelDomain
 
@@ -28,7 +27,7 @@ from fastga.models.aerodynamics.components.compute_non_equilibrated_polar import
 
 
 @oad.RegisterOpenMDAOSystem("fastga.aerodynamics.cl_cd_polar", domain=ModelDomain.AERODYNAMICS)
-class ComputePolar(Group):
+class ComputePolar(om.Group):
     def initialize(self):
         self.options.declare("cg_ratio", default=-0.0, types=float)
 

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero.py
@@ -17,7 +17,7 @@ Estimation of aero coefficients using OPENVSP.
 import logging
 
 import numpy as np
-from openmdao.core.group import Group
+import openmdao.api as om
 
 from .openvsp import OpenVSPSimpleGeometry, DEFAULT_WING_AIRFOIL, DEFAULT_HTP_AIRFOIL
 from ...components.compute_reynolds import ComputeUnitReynolds
@@ -26,7 +26,7 @@ from ...constants import SPAN_MESH_POINT, MACH_NB_PTS, DEFAULT_INPUT_AOA
 _LOGGER = logging.getLogger(__name__)
 
 
-class ComputeAeroOpenVSP(Group):
+class ComputeAeroOpenVSP(om.Group):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
         self.options.declare("compute_mach_interpolation", default=False, types=bool)

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -24,6 +24,8 @@ import fastoad.api as oad
 from fastoad.module_management._bundle_loader import BundleLoader
 from fastoad.constants import EngineSetting
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 from .openvsp import OpenVSPSimpleGeometryDP, DEFAULT_WING_AIRFOIL
 from ...components.compute_reynolds import ComputeUnitReynolds
 from ...constants import SPAN_MESH_POINT, SUBMODEL_THRUST_POWER_SLIPSTREAM
@@ -43,7 +45,7 @@ class ComputeSlipstreamOpenvsp(om.Group):
 
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("result_folder_path", default="", types=str)
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
@@ -81,7 +83,7 @@ class ComputeSlipstreamOpenvspSubGroup(om.Group):
 
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("result_folder_path", default="", types=str)
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
@@ -330,7 +332,7 @@ class PropulsionForDPComputation(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/compute_aero_slipstream.py
@@ -43,7 +43,7 @@ class ComputeSlipstreamOpenvsp(om.Group):
 
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
         self.options.declare("result_folder_path", default="", types=str)
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
@@ -81,7 +81,7 @@ class ComputeSlipstreamOpenvspSubGroup(om.Group):
 
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
         self.options.declare("result_folder_path", default="", types=str)
         self.options.declare("openvsp_exe_path", default="", types=str, allow_none=True)
         self.options.declare("airfoil_folder_path", default=None, types=str, allow_none=True)
@@ -330,7 +330,7 @@ class PropulsionForDPComputation(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
+++ b/src/fastga/models/aerodynamics/external/openvsp/openvsp.py
@@ -32,6 +32,7 @@ from stdatm import Atmosphere
 # noinspection PyProtectedMember
 from fastga.command.api import _create_tmp_directory, string_to_array
 from fastga.utils.resource_management.copy import copy_resource_from_path
+from fastga.utils.options_checkers import check_propulsion_id
 from . import openvsp3201
 from . import resources as local_resources
 from ... import airfoil_folder
@@ -1188,7 +1189,7 @@ class OpenVSPSimpleGeometryDP(OpenVSPSimpleGeometry):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/aerodynamics/external/vlm/compute_aero.py
+++ b/src/fastga/models/aerodynamics/external/vlm/compute_aero.py
@@ -17,8 +17,7 @@ Estimation of cl/cm/oswald aero coefficients using VLM.
 import logging
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
-from openmdao.core.group import Group
+import openmdao.api as om
 
 from .vlm import VLMSimpleGeometry
 from ..xfoil.xfoil_polar import XfoilPolar
@@ -32,7 +31,7 @@ DEFAULT_WING_AIRFOIL = "naca23012.af"
 DEFAULT_HTP_AIRFOIL = "naca0012.af"
 
 
-class ComputeAeroVLM(Group):
+class ComputeAeroVLM(om.Group):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
         self.options.declare("result_folder_path", default="", types=str)
@@ -169,7 +168,7 @@ class ComputeAeroVLM(Group):
             )
 
 
-class ComputeLocalReynolds(ExplicitComponent):
+class ComputeLocalReynolds(om.ExplicitComponent):
     def initialize(self):
         self.options.declare("low_speed_aero", default=False, types=bool)
 

--- a/src/fastga/models/aerodynamics/load_factor.py
+++ b/src/fastga/models/aerodynamics/load_factor.py
@@ -1,5 +1,3 @@
-"""FAST - Copyright (c) 2016 ONERA ISAE."""
-
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2022  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -31,7 +29,7 @@ class LoadFactor(Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/aerodynamics/load_factor.py
+++ b/src/fastga/models/aerodynamics/load_factor.py
@@ -27,7 +27,7 @@ class LoadFactor(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/aerodynamics/load_factor.py
+++ b/src/fastga/models/aerodynamics/load_factor.py
@@ -12,9 +12,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-
-from openmdao.core.explicitcomponent import ExplicitComponent
-from openmdao.core.group import Group
+import openmdao.api as om
 
 import fastoad.api as oad
 from fastoad.module_management.constants import ModelDomain
@@ -23,7 +21,7 @@ from .components.compute_vn import ComputeVNAndVH, DOMAIN_PTS_NB
 
 
 @oad.RegisterOpenMDAOSystem("fastga.aerodynamics.load_factor", domain=ModelDomain.AERODYNAMICS)
-class LoadFactor(Group):
+class LoadFactor(om.Group):
     """
     Models for computing the loads and characteristic speed and load factor of the aircraft
     """
@@ -40,7 +38,7 @@ class LoadFactor(Group):
         self.add_subsystem("sizing_load_factor", _LoadFactorIdentification(), promotes=["*"])
 
 
-class _LoadFactorIdentification(ExplicitComponent):
+class _LoadFactorIdentification(om.ExplicitComponent):
     def setup(self):
         nan_array = np.full(DOMAIN_PTS_NB, np.nan)
         self.add_input(

--- a/src/fastga/models/geometry/geom_components/nacelle/compute_nacelle_dimension.py
+++ b/src/fastga/models/geometry/geom_components/nacelle/compute_nacelle_dimension.py
@@ -36,7 +36,7 @@ class ComputeNacelleDimension(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/geometry/geom_components/nacelle/compute_nacelle_dimension.py
+++ b/src/fastga/models/geometry/geom_components/nacelle/compute_nacelle_dimension.py
@@ -20,6 +20,7 @@ import fastoad.api as oad
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
 from fastga.models.propulsion.fuel_propulsion.base import FuelEngineSet
+from fastga.utils.options_checkers import check_propulsion_id
 
 from ...constants import SERVICE_NACELLE_DIMENSION, SUBMODEL_NACELLE_DIMENSION_LEGACY
 
@@ -36,7 +37,7 @@ class ComputeNacelleDimension(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/geometry/geometry.py
+++ b/src/fastga/models/geometry/geometry.py
@@ -55,7 +55,7 @@ class GeometryFixedFuselage(om.Group):
     # Overriding OpenMDAO initialize
     def initialize(self):
         self.options.declare(CABIN_SIZING_OPTION, types=float, default=1.0)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -123,7 +123,7 @@ class GeometryFixedTailDistance(om.Group):
     # Overriding OpenMDAO initialize
     def initialize(self):
         self.options.declare(CABIN_SIZING_OPTION, types=float, default=1.0)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/geometry/geometry.py
+++ b/src/fastga/models/geometry/geometry.py
@@ -55,7 +55,7 @@ class GeometryFixedFuselage(om.Group):
     # Overriding OpenMDAO initialize
     def initialize(self):
         self.options.declare(CABIN_SIZING_OPTION, types=float, default=1.0)
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -123,7 +123,7 @@ class GeometryFixedTailDistance(om.Group):
     # Overriding OpenMDAO initialize
     def initialize(self):
         self.options.declare(CABIN_SIZING_OPTION, types=float, default=1.0)
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/handling_qualities/handling_qualities.py
+++ b/src/fastga/models/handling_qualities/handling_qualities.py
@@ -39,7 +39,7 @@ class ComputeHandlingQualities(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem("aero_center", ComputeAeroCenter(), promotes=["*"])

--- a/src/fastga/models/handling_qualities/handling_qualities.py
+++ b/src/fastga/models/handling_qualities/handling_qualities.py
@@ -39,7 +39,7 @@ class ComputeHandlingQualities(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem("aero_center", ComputeAeroCenter(), promotes=["*"])

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
@@ -196,7 +196,7 @@ class ComputeBalkedLandingLimit(aircraft_equilibrium_limit):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_balked_landing_limit.py
@@ -27,6 +27,8 @@ from fastoad.constants import EngineSetting
 
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 
 class aircraft_equilibrium_limit(om.ExplicitComponent):
     """
@@ -196,7 +198,7 @@ class ComputeBalkedLandingLimit(aircraft_equilibrium_limit):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_to_rotation_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_to_rotation_limit.py
@@ -35,7 +35,7 @@ class ComputeTORotationLimitGroup(om.Group):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem(
@@ -90,7 +90,7 @@ class ComputeTORotationLimit(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/handling_qualities/tail_sizing/compute_to_rotation_limit.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/compute_to_rotation_limit.py
@@ -25,6 +25,7 @@ from fastoad.constants import EngineSetting
 from stdatm import Atmosphere
 
 from fastga.command.api import list_inputs, list_outputs
+from fastga.utils.options_checkers import check_propulsion_id
 
 _ANG_VEL = 12 * np.pi / 180  # 12 deg/s (typical for light aircraft)
 
@@ -35,7 +36,7 @@ class ComputeTORotationLimitGroup(om.Group):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem(
@@ -90,7 +91,7 @@ class ComputeTORotationLimit(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/handling_qualities/tail_sizing/update_ht_area.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_ht_area.py
@@ -26,6 +26,7 @@ from fastoad.constants import EngineSetting
 from stdatm import Atmosphere
 
 from fastga.command.api import list_inputs, list_outputs
+from fastga.utils.options_checkers import check_propulsion_id
 
 from .constants import SERVICE_HT_AREA, SUBMODEL_HT_AREA_LEGACY, SUBMODEL_HT_AREA_VOLUME_COEFF
 
@@ -45,7 +46,7 @@ class UpdateHTArea(om.Group):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -127,7 +128,7 @@ class HTPConstraints(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def takeoff_rotation(self, inputs):
         n_engines = inputs["data:geometry:propulsion:engine:count"]
@@ -295,11 +296,6 @@ class _UpdateArea(HTPConstraints):
         self._engine_wrapper = None
 
     # pylint: disable=missing-function-docstring
-    # Overriding OpenMDAO initialize
-    def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
-
-    # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -374,11 +370,6 @@ class _ComputeHTPAreaConstraints(HTPConstraints):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._engine_wrapper = None
-
-    # pylint: disable=missing-function-docstring
-    # Overriding OpenMDAO initialize
-    def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -566,7 +557,7 @@ class UpdateHTAreaVolumeCoefficient(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/handling_qualities/tail_sizing/update_ht_area.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_ht_area.py
@@ -45,7 +45,7 @@ class UpdateHTArea(om.Group):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -127,7 +127,7 @@ class HTPConstraints(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def takeoff_rotation(self, inputs):
         n_engines = inputs["data:geometry:propulsion:engine:count"]
@@ -297,7 +297,7 @@ class _UpdateArea(HTPConstraints):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -378,7 +378,7 @@ class _ComputeHTPAreaConstraints(HTPConstraints):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/handling_qualities/tail_sizing/update_tail_areas.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_tail_areas.py
@@ -36,7 +36,7 @@ class UpdateTailAreas(om.Group):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
@@ -720,6 +720,11 @@ class UpdateVTAreaVolumeCoefficient(om.ExplicitComponent):
     """
 
     # pylint: disable=missing-function-docstring
+    # Overriding OpenMDAO initialize
+    def initialize(self):
+        self.options.declare("propulsion_id", default=None, allow_none=True)
+
+    # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
     def setup(self):
         self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")

--- a/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
@@ -718,6 +718,7 @@ class UpdateVTAreaVolumeCoefficient(om.ExplicitComponent):
     Computation of the area of the vertical with given volume coefficient. The formulas and
     default values are obtained from :cite:`gudmundsson:2013`.
     """
+
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
     def setup(self):

--- a/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
@@ -68,7 +68,7 @@ class VTPConstraints(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     @staticmethod
     def lateral_equilibrium(x, inputs, beta, rudder_angle, eta_v):
@@ -593,7 +593,7 @@ class _ComputeVTPAreaConstraints(VTPConstraints):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
+++ b/src/fastga/models/handling_qualities/tail_sizing/update_vt_area.py
@@ -23,6 +23,8 @@ from fastoad.module_management._bundle_loader import BundleLoader
 import fastoad.api as oad
 from fastoad.constants import EngineSetting
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 from .constants import SERVICE_VT_AREA, SUBMODEL_VT_AREA_LEGACY, SUBMODEL_VT_AREA_VOLUME_COEFF
 
 oad.RegisterSubmodel.active_models[SERVICE_VT_AREA] = SUBMODEL_VT_AREA_LEGACY
@@ -33,7 +35,7 @@ class UpdateVTArea(om.Group):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -68,7 +70,7 @@ class VTPConstraints(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     @staticmethod
     def lateral_equilibrium(x, inputs, beta, rudder_angle, eta_v):
@@ -591,11 +593,6 @@ class _ComputeVTPAreaConstraints(VTPConstraints):
         self._engine_wrapper = None
 
     # pylint: disable=missing-function-docstring
-    # Overriding OpenMDAO initialize
-    def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
-
-    # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -721,12 +718,6 @@ class UpdateVTAreaVolumeCoefficient(om.ExplicitComponent):
     Computation of the area of the vertical with given volume coefficient. The formulas and
     default values are obtained from :cite:`gudmundsson:2013`.
     """
-
-    # pylint: disable=missing-function-docstring
-    # Overriding OpenMDAO initialize
-    def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
-
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
     def setup(self):

--- a/src/fastga/models/loops/update_wing_area_group.py
+++ b/src/fastga/models/loops/update_wing_area_group.py
@@ -37,7 +37,7 @@ class UpdateWingAreaGroup(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         """Adding the update groups, the selection of the maximum and the constraints."""

--- a/src/fastga/models/loops/wing_area_component/wing_area_cl_equilibrium.py
+++ b/src/fastga/models/loops/wing_area_component/wing_area_cl_equilibrium.py
@@ -43,7 +43,7 @@ class UpdateWingAreaLiftEquilibrium(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self.add_input("data:TLAR:v_approach", val=np.nan, units="m/s")
@@ -94,7 +94,6 @@ class UpdateWingAreaLiftEquilibrium(om.ExplicitComponent):
         wing_area_approach = compute_wing_area(inputs, self.options["propulsion_id"])
 
         if wing_area_approach > 1.2 * wing_area_landing_init_guess:
-            print("Vrai valeur", wing_area_approach)
             wing_area_approach = wing_area_landing_init_guess
             _LOGGER.info(
                 "Wing area too far from potential data, taking backup value for this iteration"
@@ -115,7 +114,7 @@ class ConstraintWingAreaLiftEquilibrium(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self.add_input("data:TLAR:v_approach", val=np.nan, units="m/s")

--- a/src/fastga/models/loops/wing_area_component/wing_area_cl_equilibrium.py
+++ b/src/fastga/models/loops/wing_area_component/wing_area_cl_equilibrium.py
@@ -25,6 +25,7 @@ from fastoad.openmdao.problem import AutoUnitsDefaultGroup
 from scipy.constants import g
 
 from fastga.command.api import list_inputs_metadata
+from fastga.utils.options_checkers import check_propulsion_id
 from fastga.models.performances.mission_vector.constants import SUBMODEL_EQUILIBRIUM
 from fastga.models.performances.mission_vector.mission.dep_equilibrium import (
     DEPEquilibrium,
@@ -43,7 +44,7 @@ class UpdateWingAreaLiftEquilibrium(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self.add_input("data:TLAR:v_approach", val=np.nan, units="m/s")
@@ -114,7 +115,7 @@ class ConstraintWingAreaLiftEquilibrium(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self.add_input("data:TLAR:v_approach", val=np.nan, units="m/s")

--- a/src/fastga/models/loops/wing_area_component/wing_area_loop_cl_simple.py
+++ b/src/fastga/models/loops/wing_area_component/wing_area_loop_cl_simple.py
@@ -40,7 +40,7 @@ class UpdateWingAreaLiftSimple(om.ExplicitComponent):
 
     def initialize(self):
         # Needed for compatibility with other, more complex, module for wing sizing
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_input("data:TLAR:v_approach", val=np.nan, units="m/s")
@@ -93,7 +93,7 @@ class ConstraintWingAreaLiftSimple(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_input("data:TLAR:v_approach", val=np.nan, units="m/s")

--- a/src/fastga/models/loops/wing_area_component/wing_area_loop_cl_simple.py
+++ b/src/fastga/models/loops/wing_area_component/wing_area_loop_cl_simple.py
@@ -39,6 +39,7 @@ class UpdateWingAreaLiftSimple(om.ExplicitComponent):
     """
 
     def initialize(self):
+        # Needed for compatibility with other, more complex, module for wing sizing
         self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):

--- a/src/fastga/models/performances/mission/mission.py
+++ b/src/fastga/models/performances/mission/mission.py
@@ -52,7 +52,7 @@ class Mission(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("out_file", default="", types=str)
 
     def setup(self):

--- a/src/fastga/models/performances/mission/mission_builder_prep.py
+++ b/src/fastga/models/performances/mission/mission_builder_prep.py
@@ -28,7 +28,7 @@ from fastga.models.weight.cg.cg_variation import InFlightCGVariation
 )
 class PrepareMissionBuilder(om.Group):
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/performances/mission/mission_builder_prep.py
+++ b/src/fastga/models/performances/mission/mission_builder_prep.py
@@ -28,7 +28,7 @@ from fastga.models.weight.cg.cg_variation import InFlightCGVariation
 )
 class PrepareMissionBuilder(om.Group):
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -27,6 +27,7 @@ from fastoad.constants import EngineSetting
 
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
 from fastga.models.performances.mission.takeoff import SAFETY_HEIGHT
 
 from ..dynamic_equilibrium import DynamicEquilibrium
@@ -59,7 +60,7 @@ class ComputeClimb(DynamicEquilibrium):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/performances/mission/mission_components/climb.py
+++ b/src/fastga/models/performances/mission/mission_components/climb.py
@@ -59,7 +59,7 @@ class ComputeClimb(DynamicEquilibrium):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/performances/mission/mission_components/cruise.py
+++ b/src/fastga/models/performances/mission/mission_components/cruise.py
@@ -23,6 +23,8 @@ from fastoad.constants import EngineSetting
 
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 from ..dynamic_equilibrium import DynamicEquilibrium
 from ..constants import SUBMODEL_CRUISE
 
@@ -49,7 +51,7 @@ class ComputeCruise(DynamicEquilibrium):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/performances/mission/mission_components/cruise.py
+++ b/src/fastga/models/performances/mission/mission_components/cruise.py
@@ -49,7 +49,7 @@ class ComputeCruise(DynamicEquilibrium):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/performances/mission/mission_components/descent.py
+++ b/src/fastga/models/performances/mission/mission_components/descent.py
@@ -59,7 +59,7 @@ class ComputeDescent(DynamicEquilibrium):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/performances/mission/mission_components/descent.py
+++ b/src/fastga/models/performances/mission/mission_components/descent.py
@@ -27,6 +27,7 @@ from fastoad.constants import EngineSetting
 
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
 
 from ..dynamic_equilibrium import DynamicEquilibrium
 from ..constants import SUBMODEL_DESCENT, SUBMODEL_DESCENT_SPEED
@@ -59,7 +60,7 @@ class ComputeDescent(DynamicEquilibrium):
 
     def initialize(self):
         super().initialize()
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         super().setup()

--- a/src/fastga/models/performances/mission/mission_components/taxi.py
+++ b/src/fastga/models/performances/mission/mission_components/taxi.py
@@ -41,7 +41,7 @@ class ComputeTaxi(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
         self.options.declare("taxi_out", default=True, types=bool)
 
     def setup(self):

--- a/src/fastga/models/performances/mission/mission_components/taxi.py
+++ b/src/fastga/models/performances/mission/mission_components/taxi.py
@@ -23,6 +23,8 @@ from fastoad.constants import EngineSetting
 
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 from ..constants import SUBMODEL_TAXI
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +43,7 @@ class ComputeTaxi(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
         self.options.declare("taxi_out", default=True, types=bool)
 
     def setup(self):

--- a/src/fastga/models/performances/mission/takeoff.py
+++ b/src/fastga/models/performances/mission/takeoff.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class TakeOffPhase(om.Group):
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem(
@@ -125,7 +125,7 @@ class _v2(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -219,7 +219,7 @@ class _v_lift_off_from_v2(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -391,7 +391,7 @@ class _vr_from_v2(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -483,7 +483,7 @@ class _simulate_takeoff(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/performances/mission/takeoff.py
+++ b/src/fastga/models/performances/mission/takeoff.py
@@ -27,6 +27,7 @@ from fastoad.constants import EngineSetting
 from stdatm import Atmosphere
 
 from fastga.command.api import list_inputs, list_outputs
+from fastga.utils.options_checkers import check_propulsion_id
 
 ALPHA_LIMIT = 13.5 * np.pi / 180.0  # Limit angle to touch tail on ground in rad
 ALPHA_RATE = 3.0 * np.pi / 180.0  # Angular rotation speed in rad/s
@@ -39,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class TakeOffPhase(om.Group):
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem(
@@ -125,7 +126,7 @@ class _v2(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -219,7 +220,7 @@ class _v_lift_off_from_v2(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -391,7 +392,7 @@ class _vr_from_v2(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
@@ -483,7 +484,7 @@ class _simulate_takeoff(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/performances/mission_vector/full_mission.py
+++ b/src/fastga/models/performances/mission_vector/full_mission.py
@@ -25,7 +25,7 @@ class FullMission(om.Group):
     """Computes and potentially save mission and takeoff based on options."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("out_file", default="", types=str)
 
     def setup(self):

--- a/src/fastga/models/performances/mission_vector/mission/dep_equilibrium.py
+++ b/src/fastga/models/performances/mission_vector/mission/dep_equilibrium.py
@@ -34,7 +34,7 @@ class DEPEquilibrium(om.Group):
         self.options.declare(
             "number_of_points", default=1, desc="number of equilibrium to be treated"
         )
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare(
             "promotes_all_variables",
             default=False,

--- a/src/fastga/models/performances/mission_vector/mission/mission_core.py
+++ b/src/fastga/models/performances/mission_vector/mission/mission_core.py
@@ -30,7 +30,7 @@ class MissionCore(om.Group):
         self.options.declare(
             "number_of_points", default=1, desc="number of equilibrium to be treated"
         )
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         number_of_points = self.options["number_of_points"]

--- a/src/fastga/models/performances/mission_vector/mission/propulsion_via_id.py
+++ b/src/fastga/models/performances/mission_vector/mission/propulsion_via_id.py
@@ -19,6 +19,7 @@ from fastoad.module_management._bundle_loader import BundleLoader
 import fastoad.api as oad
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
 from fastga.models.performances.mission_vector.constants import SUBMODEL_ENERGY_CONSUMPTION
 
 oad.RegisterSubmodel.active_models[SUBMODEL_ENERGY_CONSUMPTION] = (
@@ -40,7 +41,7 @@ class FuelConsumed(om.ExplicitComponent):
         self.options.declare(
             "number_of_points", default=1, desc="number of equilibrium to be treated"
         )
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/performances/mission_vector/mission/thrust_taxi.py
+++ b/src/fastga/models/performances/mission_vector/mission/thrust_taxi.py
@@ -31,7 +31,7 @@ class ThrustTaxi(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/performances/mission_vector/mission/thrust_taxi.py
+++ b/src/fastga/models/performances/mission_vector/mission/thrust_taxi.py
@@ -20,6 +20,7 @@ from fastoad.module_management._bundle_loader import BundleLoader
 import fastoad.api as oad
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
 from fastga.models.propulsion.fuel_propulsion.base import FuelEngineSet
 
 
@@ -31,7 +32,7 @@ class ThrustTaxi(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/performances/mission_vector/mission_vector.py
+++ b/src/fastga/models/performances/mission_vector/mission_vector.py
@@ -38,7 +38,7 @@ class MissionVector(om.Group):
         self.linear_solver = om.DirectSolver()
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
         self.options.declare("out_file", default="", types=str)
 
     def setup(self):

--- a/src/fastga/models/performances/payload_range/payload_range.py
+++ b/src/fastga/models/performances/payload_range/payload_range.py
@@ -25,6 +25,7 @@ from fastoad.module_management.constants import ModelDomain
 from fastoad.openmdao.problem import AutoUnitsDefaultGroup
 
 from fastga.command import api as api_cs23
+from fastga.utils.options_checkers import check_propulsion_id
 from fastga.models.performances.mission.mission import Mission
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ class ComputePayloadRange(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         variables = api_cs23.list_variables(Mission(propulsion_id=self.options["propulsion_id"]))

--- a/src/fastga/models/performances/payload_range/payload_range.py
+++ b/src/fastga/models/performances/payload_range/payload_range.py
@@ -39,7 +39,7 @@ class ComputePayloadRange(om.ExplicitComponent):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         variables = api_cs23.list_variables(Mission(propulsion_id=self.options["propulsion_id"]))

--- a/src/fastga/models/weight/cg/cg.py
+++ b/src/fastga/models/weight/cg/cg.py
@@ -38,7 +38,7 @@ class CG(om.Group):
         self.linear_solver = om.LinearBlockGS()
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/weight/cg/cg.py
+++ b/src/fastga/models/weight/cg/cg.py
@@ -38,7 +38,7 @@ class CG(om.Group):
         self.linear_solver = om.LinearBlockGS()
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a1_wing_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a1_wing_cg.py
@@ -12,15 +12,15 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_WING_CG
 
 
 @oad.RegisterSubmodel(SUBMODEL_WING_CG, "fastga.submodel.weight.cg.airframe.wing.legacy")
-class ComputeWingCG(ExplicitComponent):
+class ComputeWingCG(om.ExplicitComponent):
     """
     Wing center of gravity estimation
 

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a2_fuselage_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a2_fuselage_cg.py
@@ -16,9 +16,9 @@ Estimation of fuselage center of gravity.
 
 import logging
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_FUSELAGE_CG
 
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @oad.RegisterSubmodel(SUBMODEL_FUSELAGE_CG, "fastga.submodel.weight.cg.airframe.fuselage.legacy")
-class ComputeFuselageCG(ExplicitComponent):
+class ComputeFuselageCG(om.ExplicitComponent):
     """
     Wing center of gravity estimation
 

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a4_flight_control_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a4_flight_control_cg.py
@@ -12,9 +12,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_FLIGHT_CONTROLS_CG
 
@@ -22,7 +22,7 @@ from ..constants import SUBMODEL_FLIGHT_CONTROLS_CG
 @oad.RegisterSubmodel(
     SUBMODEL_FLIGHT_CONTROLS_CG, "fastga.submodel.weight.cg.airframe.flight_controls.legacy"
 )
-class ComputeFlightControlCG(ExplicitComponent):
+class ComputeFlightControlCG(om.ExplicitComponent):
     """
     Control surfaces center of gravity estimation.
 

--- a/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/a_airframe/a5_landing_gear_cg.py
@@ -13,9 +13,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_LANDING_GEAR_CG
 
@@ -27,7 +27,7 @@ oad.RegisterSubmodel.active_models[SUBMODEL_LANDING_GEAR_CG] = (
 @oad.RegisterSubmodel(
     SUBMODEL_LANDING_GEAR_CG, "fastga.submodel.weight.cg.airframe.landing_gear.legacy"
 )
-class ComputeLandingGearCG(ExplicitComponent):
+class ComputeLandingGearCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """
     Landing gear center of gravity estimation based on the ratio of weight supported by each

--- a/src/fastga/models/weight/cg/cg_components/b_propulsion/b1_engine_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/b_propulsion/b1_engine_cg.py
@@ -15,10 +15,10 @@
 import warnings
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 
-class ComputeEngineCG(ExplicitComponent):
+class ComputeEngineCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Engine(s) center of gravity estimation"""
 

--- a/src/fastga/models/weight/cg/cg_components/b_propulsion/b2_fuel_lines_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/b_propulsion/b2_fuel_lines_cg.py
@@ -13,10 +13,10 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 
-class ComputeFuelLinesCG(ExplicitComponent):
+class ComputeFuelLinesCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Fuel lines center of gravity estimation"""
 

--- a/src/fastga/models/weight/cg/cg_components/b_propulsion/b3_tank_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/b_propulsion/b3_tank_cg.py
@@ -12,15 +12,15 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_TANK_CG
 
 
 @oad.RegisterSubmodel(SUBMODEL_TANK_CG, "fastga.submodel.weight.cg.propulsion.tank.legacy")
-class ComputeTankCG(ExplicitComponent):
+class ComputeTankCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Fuel tank center of gravity estimation"""
 

--- a/src/fastga/models/weight/cg/cg_components/c_systems/c1_power_systems_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/c_systems/c1_power_systems_cg.py
@@ -13,9 +13,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_POWER_SYSTEMS_CG
 
@@ -23,7 +23,7 @@ from ..constants import SUBMODEL_POWER_SYSTEMS_CG
 @oad.RegisterSubmodel(
     SUBMODEL_POWER_SYSTEMS_CG, "fastga.submodel.weight.cg.system.power_system.legacy"
 )
-class ComputePowerSystemsCG(ExplicitComponent):
+class ComputePowerSystemsCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Power systems center(s) of gravity estimation."""
 

--- a/src/fastga/models/weight/cg/cg_components/c_systems/c2_life_support_systems_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/c_systems/c2_life_support_systems_cg.py
@@ -12,9 +12,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_LIFE_SUPPORT_SYSTEMS_CG
 
@@ -22,7 +22,7 @@ from ..constants import SUBMODEL_LIFE_SUPPORT_SYSTEMS_CG
 @oad.RegisterSubmodel(
     SUBMODEL_LIFE_SUPPORT_SYSTEMS_CG, "fastga.submodel.weight.cg.system.life_support_system.legacy"
 )
-class ComputeLifeSupportCG(ExplicitComponent):
+class ComputeLifeSupportCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Life support systems center of gravity estimation."""
 

--- a/src/fastga/models/weight/cg/cg_components/c_systems/c3_navigation_systems_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/c_systems/c3_navigation_systems_cg.py
@@ -12,9 +12,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_NAVIGATION_SYSTEMS_CG
 
@@ -22,7 +22,7 @@ from ..constants import SUBMODEL_NAVIGATION_SYSTEMS_CG
 @oad.RegisterSubmodel(
     SUBMODEL_NAVIGATION_SYSTEMS_CG, "fastga.submodel.weight.cg.system.navigation_system.legacy"
 )
-class ComputeNavigationSystemsCG(ExplicitComponent):
+class ComputeNavigationSystemsCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Navigation systems center of gravity estimation."""
 

--- a/src/fastga/models/weight/cg/cg_components/c_systems/c4_recording_systems_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/c_systems/c4_recording_systems_cg.py
@@ -12,9 +12,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_RECORDING_SYSTEMS_CG
 
@@ -22,7 +22,7 @@ from ..constants import SUBMODEL_RECORDING_SYSTEMS_CG
 @oad.RegisterSubmodel(
     SUBMODEL_RECORDING_SYSTEMS_CG, "fastga.submodel.weight.cg.system.recording_system.legacy"
 )
-class ComputeRecordingSystemsCG(ExplicitComponent):
+class ComputeRecordingSystemsCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """
     Recording systems center of gravity estimation. Recording systems assumed to be in the tail.

--- a/src/fastga/models/weight/cg/cg_components/d_furniture/d2_passenger_seats_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/d_furniture/d2_passenger_seats_cg.py
@@ -12,15 +12,15 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from ..constants import SUBMODEL_SEATS_CG
 
 
 @oad.RegisterSubmodel(SUBMODEL_SEATS_CG, "fastga.submodel.weight.cg.furniture.seats.legacy")
-class ComputePassengerSeatsCG(ExplicitComponent):
+class ComputePassengerSeatsCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Passenger seats center of gravity estimation"""
 

--- a/src/fastga/models/weight/cg/cg_components/global_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/global_cg.py
@@ -12,8 +12,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import openmdao.api as om
 import fastoad.api as oad
-from openmdao.api import Group
 
 from .constants import (
     SUBMODEL_AIRCRAFT_X_CG_RATIO,
@@ -25,7 +25,7 @@ from .max_cg_ratio import ComputeMaxMinCGRatio
 
 
 @oad.RegisterSubmodel(SUBMODEL_AIRCRAFT_CG_EXTREME, "fastga.submodel.weight.cg.aircraft.x.legacy")
-class ComputeGlobalCG(Group):
+class ComputeGlobalCG(om.Group):
     # TODO: Document equations. Cite sources
     """Global center of gravity estimation."""
 

--- a/src/fastga/models/weight/cg/cg_components/global_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/global_cg.py
@@ -30,7 +30,7 @@ class ComputeGlobalCG(om.Group):
     """Global center of gravity estimation."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/weight/cg/cg_components/global_cg.py
+++ b/src/fastga/models/weight/cg/cg_components/global_cg.py
@@ -30,7 +30,7 @@ class ComputeGlobalCG(Group):
     """Global center of gravity estimation."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         self.add_subsystem(

--- a/src/fastga/models/weight/cg/cg_components/loadcase.py
+++ b/src/fastga/models/weight/cg/cg_components/loadcase.py
@@ -111,7 +111,7 @@ class ComputeFlightCGCase(ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/weight/cg/cg_components/loadcase.py
+++ b/src/fastga/models/weight/cg/cg_components/loadcase.py
@@ -15,14 +15,14 @@ New estimation method of center of gravity for all load cases.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
 import scipy.optimize as optimize
+import openmdao.api as om
+import fastoad.api as oad
 from fastoad.constants import EngineSetting
 
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
-from openmdao.core.explicitcomponent import ExplicitComponent
 from scipy.constants import g
 from stdatm import Atmosphere
 
@@ -32,7 +32,7 @@ from .constants import SUBMODEL_LOADCASE_GROUND_X, SUBMODEL_LOADCASE_FLIGHT_X
 @oad.RegisterSubmodel(
     SUBMODEL_LOADCASE_GROUND_X, "fastga.submodel.weight.cg.loadcase.ground.legacy"
 )
-class ComputeGroundCGCase(ExplicitComponent):
+class ComputeGroundCGCase(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Center of gravity estimation for all load cases on ground."""
 
@@ -103,7 +103,7 @@ class ComputeGroundCGCase(ExplicitComponent):
 @oad.RegisterSubmodel(
     SUBMODEL_LOADCASE_FLIGHT_X, "fastga.submodel.weight.cg.loadcase.flight.legacy"
 )
-class ComputeFlightCGCase(ExplicitComponent):
+class ComputeFlightCGCase(om.ExplicitComponent):
     """Center of gravity estimation for all load cases in flight"""
 
     def __init__(self, **kwargs):

--- a/src/fastga/models/weight/cg/cg_components/loadcase.py
+++ b/src/fastga/models/weight/cg/cg_components/loadcase.py
@@ -26,6 +26,7 @@ from fastoad.module_management._bundle_loader import BundleLoader
 from scipy.constants import g
 from stdatm import Atmosphere
 
+from fastga.utils.options_checkers import check_propulsion_id
 from .constants import SUBMODEL_LOADCASE_GROUND_X, SUBMODEL_LOADCASE_FLIGHT_X
 
 
@@ -111,7 +112,7 @@ class ComputeFlightCGCase(om.ExplicitComponent):
         self._engine_wrapper = None
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     def setup(self):
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])

--- a/src/fastga/models/weight/cg/cg_components/max_cg_ratio.py
+++ b/src/fastga/models/weight/cg/cg_components/max_cg_ratio.py
@@ -16,10 +16,10 @@ Estimation of maximum center of gravity ratio.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 
-class ComputeMaxMinCGRatio(ExplicitComponent):
+class ComputeMaxMinCGRatio(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Extrema center of gravity ratio estimation"""
 

--- a/src/fastga/models/weight/cg/cg_components/payload.py
+++ b/src/fastga/models/weight/cg/cg_components/payload.py
@@ -15,15 +15,15 @@ Estimation of payload center(s) of gravity.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from .constants import SUBMODEL_PAYLOAD_CG
 
 
 @oad.RegisterSubmodel(SUBMODEL_PAYLOAD_CG, "fastga.submodel.weight.cg.payload.legacy")
-class ComputePayloadCG(ExplicitComponent):
+class ComputePayloadCG(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Payload center(s) of gravity estimation"""
 

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_2_oil_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_2_oil_weight.py
@@ -37,7 +37,7 @@ class ComputeOilWeight(ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_2_oil_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_2_oil_weight.py
@@ -22,6 +22,8 @@ from fastoad.constants import EngineSetting
 from fastoad.module_management._bundle_loader import BundleLoader
 from scipy.constants import lbf
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 
 class ComputeOilWeight(om.ExplicitComponent):
     """
@@ -37,7 +39,7 @@ class ComputeOilWeight(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_2_oil_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_2_oil_weight.py
@@ -14,16 +14,16 @@ Python module for oil weight calculation, part of the propulsion system mass com
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import openmdao.api as om
 import fastoad.api as oad
 from fastoad.constants import EngineSetting
 
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
-from openmdao.core.explicitcomponent import ExplicitComponent
 from scipy.constants import lbf
 
 
-class ComputeOilWeight(ExplicitComponent):
+class ComputeOilWeight(om.ExplicitComponent):
     """
     Weight estimation for motor oil.
 

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -46,7 +46,7 @@ class ComputeEngineWeight(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -108,7 +108,7 @@ class ComputeEngineWeightRaymer(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -20,6 +20,8 @@ import openmdao.api as om
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
 
+from fastga.utils.options_checkers import check_propulsion_id
+
 from .constants import (
     SERVICE_INSTALLED_ENGINE_MASS,
     SUBMODEL_INSTALLED_ENGINE_MASS_LEGACY,
@@ -46,7 +48,7 @@ class ComputeEngineWeight(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup
@@ -108,7 +110,7 @@ class ComputeEngineWeightRaymer(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b2_fuel_lines_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b2_fuel_lines_weight.py
@@ -16,9 +16,9 @@ Python module for fuel lines weight calculation, part of the propulsion system m
 
 import warnings
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from .constants import (
     SERVICE_FUEL_SYSTEM_MASS,
@@ -30,7 +30,7 @@ oad.RegisterSubmodel.active_models[SERVICE_FUEL_SYSTEM_MASS] = SUBMODEL_FUEL_SYS
 
 
 @oad.RegisterSubmodel(SERVICE_FUEL_SYSTEM_MASS, SUBMODEL_FUEL_SYSTEM_MASS_LEGACY)
-class ComputeFuelLinesWeight(ExplicitComponent):
+class ComputeFuelLinesWeight(om.ExplicitComponent):
     """
     Weight estimation for fuel lines
 
@@ -131,7 +131,7 @@ class ComputeFuelLinesWeight(ExplicitComponent):
 
 
 @oad.RegisterSubmodel(SERVICE_FUEL_SYSTEM_MASS, SUBMODEL_FUEL_SYSTEM_MASS_FLOPS)
-class ComputeFuelLinesWeightFLOPS(ExplicitComponent):
+class ComputeFuelLinesWeightFLOPS(om.ExplicitComponent):
     """
     Weight estimation for fuel lines
 

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b3_unusable_fuel_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b3_unusable_fuel_weight.py
@@ -43,7 +43,7 @@ class ComputeUnusableFuelWeight(ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b3_unusable_fuel_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b3_unusable_fuel_weight.py
@@ -14,13 +14,13 @@ Python module for unsuable fuel weight calculation, part of the propulsion syste
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
+import openmdao.api as om
+import fastoad.api as oad
 from fastoad.constants import EngineSetting
 
 # noinspection PyProtectedMember
 from fastoad.module_management._bundle_loader import BundleLoader
-from openmdao.core.explicitcomponent import ExplicitComponent
 from scipy.constants import lbf
 
 from .constants import SERVICE_UNUSABLE_FUEL_MASS, SUBMODEL_UNUSABLE_FUEL_MASS_LEGACY
@@ -29,7 +29,7 @@ oad.RegisterSubmodel.active_models[SERVICE_UNUSABLE_FUEL_MASS] = SUBMODEL_UNUSAB
 
 
 @oad.RegisterSubmodel(SERVICE_UNUSABLE_FUEL_MASS, SUBMODEL_UNUSABLE_FUEL_MASS_LEGACY)
-class ComputeUnusableFuelWeight(ExplicitComponent):
+class ComputeUnusableFuelWeight(om.ExplicitComponent):
     """
     Weight estimation for motor oil
 

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/b3_unusable_fuel_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/b3_unusable_fuel_weight.py
@@ -23,6 +23,7 @@ from fastoad.constants import EngineSetting
 from fastoad.module_management._bundle_loader import BundleLoader
 from scipy.constants import lbf
 
+from fastga.utils.options_checkers import check_propulsion_id
 from .constants import SERVICE_UNUSABLE_FUEL_MASS, SUBMODEL_UNUSABLE_FUEL_MASS_LEGACY
 
 oad.RegisterSubmodel.active_models[SERVICE_UNUSABLE_FUEL_MASS] = SUBMODEL_UNUSABLE_FUEL_MASS_LEGACY
@@ -43,7 +44,7 @@ class ComputeUnusableFuelWeight(om.ExplicitComponent):
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO initialize
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str)
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
 
     # pylint: disable=missing-function-docstring
     # Overriding OpenMDAO setup

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/sum.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/sum.py
@@ -31,7 +31,7 @@ class PropulsionWeight(om.Group):
     """Computes mass of propulsion system."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         propulsion_option = {"propulsion_id": self.options["propulsion_id"]}

--- a/src/fastga/models/weight/mass_breakdown/b_propulsion/sum.py
+++ b/src/fastga/models/weight/mass_breakdown/b_propulsion/sum.py
@@ -31,7 +31,7 @@ class PropulsionWeight(om.Group):
     """Computes mass of propulsion system."""
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         propulsion_option = {"propulsion_id": self.options["propulsion_id"]}

--- a/src/fastga/models/weight/mass_breakdown/c_systems/c1_power_systems_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/c_systems/c1_power_systems_weight.py
@@ -14,15 +14,15 @@ Python module for power systems weight calculation, part of the systems mass com
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from .constants import SERVICE_POWER_SYSTEM_MASS, SUBMODEL_POWER_SYSTEM_MASS_LEGACY
 
 
 @oad.RegisterSubmodel(SERVICE_POWER_SYSTEM_MASS, SUBMODEL_POWER_SYSTEM_MASS_LEGACY)
-class ComputePowerSystemsWeight(ExplicitComponent):
+class ComputePowerSystemsWeight(om.ExplicitComponent):
     """
     Weight estimation for power systems (generation and distribution)
 

--- a/src/fastga/models/weight/mass_breakdown/c_systems/c2_life_support_systems_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/c_systems/c2_life_support_systems_weight.py
@@ -14,10 +14,10 @@ Python module for life support systems weight calculation, part of the systems m
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 from stdatm import Atmosphere
+import fastoad.api as oad
 
 from .constants import (
     SERVICE_LIFE_SUPPORT_SYSTEM_MASS,
@@ -34,7 +34,7 @@ oad.RegisterSubmodel.active_models[SERVICE_LIFE_SUPPORT_SYSTEM_MASS] = (
     SERVICE_LIFE_SUPPORT_SYSTEM_MASS,
     SUBMODEL_LIFE_SUPPORT_SYSTEM_MASS_LEGACY,
 )
-class ComputeLifeSupportSystemsWeight(ExplicitComponent):
+class ComputeLifeSupportSystemsWeight(om.ExplicitComponent):
     """
     Weight estimation for life support systems
 
@@ -168,7 +168,7 @@ class ComputeLifeSupportSystemsWeight(ExplicitComponent):
     SERVICE_LIFE_SUPPORT_SYSTEM_MASS,
     SUBMODEL_LIFE_SUPPORT_SYSTEM_MASS_FLOPS,
 )
-class ComputeLifeSupportSystemsWeightFLOPS(ExplicitComponent):
+class ComputeLifeSupportSystemsWeightFLOPS(om.ExplicitComponent):
     """
     Weight estimation for life support systems
 

--- a/src/fastga/models/weight/mass_breakdown/c_systems/c3_avionics_systems_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/c_systems/c3_avionics_systems_weight.py
@@ -14,9 +14,9 @@ Python module for navigation systems weight calculation, part of the systems mas
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from .constants import (
     SERVICE_AVIONICS_SYSTEM_MASS,
@@ -33,7 +33,7 @@ oad.RegisterSubmodel.active_models[SERVICE_AVIONICS_SYSTEM_MASS] = (
     SERVICE_AVIONICS_SYSTEM_MASS,
     SUBMODEL_AVIONICS_SYSTEM_MASS_LEGACY,
 )
-class ComputeAvionicsSystemsWeight(ExplicitComponent):
+class ComputeAvionicsSystemsWeight(om.ExplicitComponent):
     """
     Weight estimation for avionics systems. Takes into account the weight of:
     - Instrumentation
@@ -98,7 +98,7 @@ class ComputeAvionicsSystemsWeight(ExplicitComponent):
     SERVICE_AVIONICS_SYSTEM_MASS,
     SUBMODEL_AVIONICS_SYSTEM_MASS_FROM_UNINSTALLED,
 )
-class ComputeAvionicsSystemsWeightFromUninstalled(ExplicitComponent):
+class ComputeAvionicsSystemsWeightFromUninstalled(om.ExplicitComponent):
     """
     Weight estimation for avionics systems. Takes into account the weight of:
     - Instrumentation

--- a/src/fastga/models/weight/mass_breakdown/c_systems/c4_recording_systems_weight.py
+++ b/src/fastga/models/weight/mass_breakdown/c_systems/c4_recording_systems_weight.py
@@ -14,9 +14,9 @@ Python module for recording systems weight calculation, part of the systems mass
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
+import fastoad.api as oad
 
 from .constants import SERVICE_RECORDING_SYSTEM_MASS, SUBMODEL_RECORDING_SYSTEM_MASS_MINIMUM
 
@@ -29,7 +29,7 @@ oad.RegisterSubmodel.active_models[SERVICE_RECORDING_SYSTEM_MASS] = (
     SERVICE_RECORDING_SYSTEM_MASS,
     SUBMODEL_RECORDING_SYSTEM_MASS_MINIMUM,
 )
-class ComputeRecordingSystemsWeight(ExplicitComponent):
+class ComputeRecordingSystemsWeight(om.ExplicitComponent):
     """
     Weight estimation for recording systems, not mandatory for airplane with weight under 5600 kg
     but the designer can add them. Indicative values are used based on the weight of DFDR and CVR

--- a/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
+++ b/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
@@ -57,7 +57,7 @@ class MassBreakdown(om.Group):
 
     def initialize(self):
         self.options.declare(PAYLOAD_FROM_NPAX, types=bool, default=True)
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         if self.options[PAYLOAD_FROM_NPAX]:
@@ -93,7 +93,7 @@ class ComputeOperatingWeightEmpty(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         # Airframe

--- a/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
+++ b/src/fastga/models/weight/mass_breakdown/mass_breakdown.py
@@ -57,7 +57,7 @@ class MassBreakdown(om.Group):
 
     def initialize(self):
         self.options.declare(PAYLOAD_FROM_NPAX, types=bool, default=True)
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         if self.options[PAYLOAD_FROM_NPAX]:
@@ -93,7 +93,7 @@ class ComputeOperatingWeightEmpty(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         # Airframe

--- a/src/fastga/models/weight/mass_breakdown/update_mlw_and_mzfw.py
+++ b/src/fastga/models/weight/mass_breakdown/update_mlw_and_mzfw.py
@@ -15,10 +15,10 @@ Main component for mass breakdown.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 
-class UpdateMLWandMZFW(ExplicitComponent):
+class UpdateMLWandMZFW(om.ExplicitComponent):
     """
     Computes Maximum Landing Weight and Maximum Zero Fuel Weight from
     Overall Empty Weight and Maximum Payload.

--- a/src/fastga/models/weight/mass_breakdown/update_mtow.py
+++ b/src/fastga/models/weight/mass_breakdown/update_mtow.py
@@ -14,14 +14,14 @@ Main component for mass breakdown.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fastoad.api as oad
 import numpy as np
+import openmdao.api as om
+import fastoad.api as oad
 from fastoad.module_management.constants import ModelDomain
-from openmdao.core.explicitcomponent import ExplicitComponent
 
 
 @oad.RegisterOpenMDAOSystem("fastga.loop.mtow", domain=ModelDomain.OTHER)
-class UpdateMTOW(ExplicitComponent):
+class UpdateMTOW(om.ExplicitComponent):
     """
     Computes Maximum Take-Off Weight from Maximum Zero Fuel Weight and fuel weight.
     """

--- a/src/fastga/models/weight/weight.py
+++ b/src/fastga/models/weight/weight.py
@@ -36,7 +36,7 @@ class Weight(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default="", types=str)
+        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
 
     def setup(self):
         propulsion_option = {"propulsion_id": self.options["propulsion_id"]}

--- a/src/fastga/models/weight/weight.py
+++ b/src/fastga/models/weight/weight.py
@@ -36,7 +36,7 @@ class Weight(om.Group):
     """
 
     def initialize(self):
-        self.options.declare("propulsion_id", default=None, types=str, allow_none=True)
+        self.options.declare("propulsion_id", default=None, allow_none=True)
 
     def setup(self):
         propulsion_option = {"propulsion_id": self.options["propulsion_id"]}

--- a/src/fastga/utils/options_checkers.py
+++ b/src/fastga/utils/options_checkers.py
@@ -26,4 +26,4 @@ def check_propulsion_id(name: str, value):
     if value is None:
         raise ValueError(f"Option '{name}' is expected to be a string, not None")
     if not isinstance(value, str):
-        raise ValueError(f"Option '{name}' is expected to be a string, not a {type(value)}")
+        raise ValueError(f"Option '{name}' is expected to be a string, not a {type(value).__name__}")

--- a/src/fastga/utils/options_checkers.py
+++ b/src/fastga/utils/options_checkers.py
@@ -11,6 +11,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
 def check_propulsion_id(name: str, value):
     if value is None:
         raise ValueError(f"Option '{name}' is expected to be a string, not None")

--- a/src/fastga/utils/options_checkers.py
+++ b/src/fastga/utils/options_checkers.py
@@ -26,4 +26,6 @@ def check_propulsion_id(name: str, value):
     if value is None:
         raise ValueError(f"Option '{name}' is expected to be a string, not None")
     if not isinstance(value, str):
-        raise ValueError(f"Option '{name}' is expected to be a string, not a {type(value).__name__}")
+        raise ValueError(
+            f"Option '{name}' is expected to be a string, not a {type(value).__name__}"
+        )

--- a/src/fastga/utils/options_checkers.py
+++ b/src/fastga/utils/options_checkers.py
@@ -1,0 +1,18 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+def check_propulsion_id(name: str, value):
+    if value is None:
+        raise ValueError(f"Option '{name}' is expected to be a string, not None")
+    elif not isinstance(value, str):
+        raise ValueError(f"Option '{name}' is expected to be a string, not a {type(value)}")

--- a/src/fastga/utils/options_checkers.py
+++ b/src/fastga/utils/options_checkers.py
@@ -1,3 +1,6 @@
+"""
+Module for options validating functions.
+"""
 #  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2022  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -13,7 +16,14 @@
 
 
 def check_propulsion_id(name: str, value):
+    """
+    This is a function for validating propulsion_id options. It checks whether the option is set
+    to 'None' or is not a string. It is not factorised on purpose so that the error message is
+    slightly more explicit. This will also help with debugging. If the option is 'None',
+    this will likely be because the option was not passed down correctly by parent group. If it
+    is not a string, it will probably be because the user has not set the right type of option.
+    """
     if value is None:
         raise ValueError(f"Option '{name}' is expected to be a string, not None")
-    elif not isinstance(value, str):
+    if not isinstance(value, str):
         raise ValueError(f"Option '{name}' is expected to be a string, not a {type(value)}")

--- a/src/fastga/utils/unitary_tests/__init__.py
+++ b/src/fastga/utils/unitary_tests/__init__.py
@@ -1,0 +1,12 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/fastga/utils/unitary_tests/test_propulsion_id_check.py
+++ b/src/fastga/utils/unitary_tests/test_propulsion_id_check.py
@@ -1,0 +1,86 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import pytest
+
+import fastoad.api as oad
+
+from tests.dummy_plugins.dummy_plugin_1.models.dummy_group import DummyGroup, DUMMY_SERVICE
+
+
+def test_fails_when_none_and_required(with_dummy_plugin_1):
+    """
+    Test that the problem can't setup when the propulsion id is specified as None and is required in
+    the correct format.
+    """
+
+    oad.RegisterSubmodel.active_models[DUMMY_SERVICE] = "dummy_submodel_1"
+
+    problem = oad.FASTOADProblem()
+    model = problem.model
+    model.add_subsystem(name="dummy_group", subsys=DummyGroup(propulsion_id=None), promotes=["*"])
+
+    with pytest.raises(ValueError) as e:
+        problem.setup()
+
+    # Check the error message
+    assert e.value.args[0] == "Option 'propulsion_id' is expected to be a string, not None"
+
+
+def test_fails_when_not_specified_and_required(with_dummy_plugin_1):
+    """
+    Test that the problem can't setup when the propulsion id is not specified and is required in
+    the correct format.
+    """
+
+    oad.RegisterSubmodel.active_models[DUMMY_SERVICE] = "dummy_submodel_1"
+
+    problem = oad.FASTOADProblem()
+    model = problem.model
+    model.add_subsystem(name="dummy_group", subsys=DummyGroup(), promotes=["*"])
+
+    with pytest.raises(ValueError) as e:
+        problem.setup()
+
+    # Check the error message
+    assert e.value.args[0] == "Option 'propulsion_id' is expected to be a string, not None"
+
+
+def test_fails_when_invalid_and_required(with_dummy_plugin_1):
+    """
+    Test that the problem can't setup when the propulsion id is not set correctly and is required in
+    the correct format.
+    """
+
+    oad.RegisterSubmodel.active_models[DUMMY_SERVICE] = "dummy_submodel_1"
+
+    problem = oad.FASTOADProblem()
+    model = problem.model
+    model.add_subsystem(
+        name="dummy_group", subsys=DummyGroup(propulsion_id=(48.5734053, 7.7521113)), promotes=["*"]
+    )
+
+    with pytest.raises(ValueError) as e:
+        problem.setup()
+
+    # Check the error message
+    assert e.value.args[0] == "Option 'propulsion_id' is expected to be a string, not a tuple"
+
+
+def test_does_not_fail_when_not_required(with_dummy_plugin_1):
+    oad.RegisterSubmodel.active_models[DUMMY_SERVICE] = "dummy_submodel_2"
+
+    problem = oad.FASTOADProblem()
+    model = problem.model
+    model.add_subsystem(name="dummy_group", subsys=DummyGroup(), promotes=["*"])
+    problem.setup()

--- a/tests/dummy_plugins/__init__.py
+++ b/tests/dummy_plugins/__init__.py
@@ -1,0 +1,12 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/tests/dummy_plugins/dummy_plugin_1/__init__.py
+++ b/tests/dummy_plugins/dummy_plugin_1/__init__.py
@@ -1,0 +1,12 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/tests/dummy_plugins/dummy_plugin_1/models/__init__.py
+++ b/tests/dummy_plugins/dummy_plugin_1/models/__init__.py
@@ -1,0 +1,12 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/tests/dummy_plugins/dummy_plugin_1/models/constants.py
+++ b/tests/dummy_plugins/dummy_plugin_1/models/constants.py
@@ -1,0 +1,14 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+DUMMY_SERVICE = "dummy_service"

--- a/tests/dummy_plugins/dummy_plugin_1/models/dummy_components.py
+++ b/tests/dummy_plugins/dummy_plugin_1/models/dummy_components.py
@@ -1,0 +1,51 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2022  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+import fastoad.api as oad
+
+from fastga.utils.options_checkers import check_propulsion_id
+
+from .constants import DUMMY_SERVICE
+
+
+@oad.RegisterSubmodel(DUMMY_SERVICE, "dummy_submodel_1")
+class DummyComponent1(om.ExplicitComponent):
+
+    def initialize(self):
+        # Actually "requires" the propulsion id in the right format
+        self.options.declare("propulsion_id", check_valid=check_propulsion_id)
+
+    def setup(self):
+        self.add_input(name="dummy_input_1", val=1.0, units="m**2")
+
+        self.add_output(name="dummy_output_1", val=42.0, units="kg")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        outputs["dummy_output_1"] = 10 + 32.0 * inputs["dummy_input_1"]
+
+
+@oad.RegisterSubmodel(DUMMY_SERVICE, "dummy_submodel_2")
+class DummyComponent2(om.ExplicitComponent):
+
+    def initialize(self):
+        # Does not need the option but has it anyway for compatibility
+        self.options.declare("propulsion_id", default=None, allow_none=True)
+
+    def setup(self):
+        self.add_input(name="dummy_input_2", val=41.46875, units="m**2")
+
+        self.add_output(name="dummy_output_1", val=42.0, units="kg")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        outputs["dummy_output_1"] = 10 + 32.0 * inputs["dummy_input_1"]

--- a/tests/dummy_plugins/dummy_plugin_1/models/dummy_group.py
+++ b/tests/dummy_plugins/dummy_plugin_1/models/dummy_group.py
@@ -1,0 +1,36 @@
+#  This file is part of FAST-OAD_CS23 : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+import fastoad.api as oad
+
+from .constants import DUMMY_SERVICE
+
+
+class DummyGroup(om.Group):
+
+    def initialize(self):
+        # Option is not used there strictly speaking, so we allow it to be None
+        self.options.declare("propulsion_id", default=None, allow_none=True)
+
+    def setup(self):
+        propulsion_option = {"propulsion_id": self.options["propulsion_id"]}
+
+        self.add_subsystem(
+            name="dummy_subsystem",
+            subsys=oad.RegisterSubmodel.get_submodel(
+                service_id=DUMMY_SERVICE,
+                options=propulsion_option
+            ),
+            promotes=["*"]
+        )


### PR DESCRIPTION
This pull request brings two changes:
- A minor change to the import of OpenMDAO components that were previously imported directly. We now resort to the API to future-proof the codebase. This brings no changes to the results.
- A change to the way the propulsion_id is handled. We now switch to a logic where only bottom-level components that *really* require that ID define it as being mandatory. That way, if we replace a model that needs it with one that doesn't (and even though it will be required to define it for compatibility), it can be set as `None` and never be used. By the way, the new default value for the id is now `None`. In terms of clarity, it enables the propulsion not to be declared in the configuration file if no submodel uses it. And it doesn't change anything if model_options are used. 